### PR TITLE
Wishlist: persistence, move-to-bag, mobile menu (#6)

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -317,6 +317,58 @@ export default function Navbar() {
                 <div className="mt-auto">
                   <div className="h-px w-full mb-6" style={{ background: "rgba(255,255,255,0.08)" }} />
 
+                  {/* Wishlist + Bag triggers */}
+                  {[
+                    {
+                      Icon: Heart,
+                      label: "Wishlist",
+                      badge: wishlistItems.length,
+                      onClick: () => {
+                        setMobileOpen(false);
+                        setWishlistOpen(true);
+                      },
+                    },
+                    {
+                      Icon: ShoppingBag,
+                      label: "Bag",
+                      badge: itemCount,
+                      onClick: () => {
+                        setMobileOpen(false);
+                        setCartOpen(true);
+                      },
+                    },
+                  ].map(({ Icon, label, badge, onClick }) => (
+                    <button
+                      key={label}
+                      onClick={onClick}
+                      className="flex items-center gap-3 mb-5 w-full text-left text-white/75 hover:text-[#e8c4ad] transition-colors duration-300"
+                    >
+                      <span
+                        className="relative w-9 h-9 rounded-full flex items-center justify-center flex-shrink-0"
+                        style={{
+                          background: "rgba(255,255,255,0.08)",
+                          border: "1px solid rgba(255,255,255,0.1)",
+                        }}
+                      >
+                        <Icon size={16} />
+                        {badge > 0 && (
+                          <span className="absolute -top-1 -right-1 w-4 h-4 rounded-full bg-[#c9977a] text-white text-[9px] flex items-center justify-center font-bold">
+                            {badge}
+                          </span>
+                        )}
+                      </span>
+                      <span
+                        style={{
+                          fontFamily: "var(--font-cormorant)",
+                          fontSize: "1.35rem",
+                          fontWeight: 400,
+                        }}
+                      >
+                        {label}
+                      </span>
+                    </button>
+                  ))}
+
                   {/* Auth link */}
                   <Link
                     href={user ? "/account" : "/login"}

--- a/src/components/WishlistSidebar.tsx
+++ b/src/components/WishlistSidebar.tsx
@@ -2,21 +2,32 @@
 
 import Image from "next/image";
 import { motion, AnimatePresence } from "framer-motion";
-import { X, Heart } from "lucide-react";
-import { useWishlist } from "@/context/WishlistContext";
+import { X, Heart, ShoppingBag } from "lucide-react";
+import { useWishlist, type WishlistProduct } from "@/context/WishlistContext";
 import { useCart } from "@/context/CartContext";
 import SideDrawer from "@/components/SideDrawer";
 import { ease } from "@/lib/motion";
 
 export default function WishlistSidebar() {
-  const { items, wishlistOpen, setWishlistOpen, toggleItem } = useWishlist();
+  const { items, wishlistOpen, setWishlistOpen, toggleItem, clearWishlist } =
+    useWishlist();
   const { addItem, setCartOpen } = useCart();
 
-  // Move every saved item into the bag, then hand off to the cart.
+  // Move every saved item into the bag (and out of the wishlist), then hand
+  // off to the cart.
   const handleShopAll = () => {
     items.forEach((item) => addItem(item));
+    clearWishlist();
     setWishlistOpen(false);
     setCartOpen(true);
+  };
+
+  // Move a single saved item into the bag and remove it from the wishlist.
+  // No auto-open of the cart — the "Added to bag" toast confirms it (matches
+  // the product-card add behaviour).
+  const handleMoveToBag = (item: WishlistProduct) => {
+    addItem(item);
+    toggleItem(item);
   };
 
   return (
@@ -152,20 +163,36 @@ export default function WishlistSidebar() {
                   </p>
                 </div>
 
-                {/* Remove button */}
-                <motion.button
-                  whileHover={{ scale: 1.1 }}
-                  whileTap={{ scale: 0.88 }}
-                  onClick={() => toggleItem(item)}
-                  className="w-8 h-8 flex items-center justify-center rounded-full flex-shrink-0"
-                  style={{
-                    background: "rgba(239,68,68,0.07)",
-                    border: "1px solid rgba(239,68,68,0.18)",
-                  }}
-                  aria-label={`Remove ${item.name} from wishlist`}
-                >
-                  <X size={12} style={{ color: "rgba(239,68,68,0.7)" }} />
-                </motion.button>
+                {/* Actions — move to bag / remove */}
+                <div className="flex flex-col gap-2 flex-shrink-0">
+                  <motion.button
+                    whileHover={{ scale: 1.1 }}
+                    whileTap={{ scale: 0.88 }}
+                    onClick={() => handleMoveToBag(item)}
+                    className="w-8 h-8 flex items-center justify-center rounded-full"
+                    style={{
+                      background: "rgba(201,151,122,0.1)",
+                      border: "1px solid rgba(201,151,122,0.25)",
+                    }}
+                    aria-label={`Move ${item.name} to bag`}
+                  >
+                    <ShoppingBag size={12} className="text-rose-gold" />
+                  </motion.button>
+
+                  <motion.button
+                    whileHover={{ scale: 1.1 }}
+                    whileTap={{ scale: 0.88 }}
+                    onClick={() => toggleItem(item)}
+                    className="w-8 h-8 flex items-center justify-center rounded-full"
+                    style={{
+                      background: "rgba(239,68,68,0.07)",
+                      border: "1px solid rgba(239,68,68,0.18)",
+                    }}
+                    aria-label={`Remove ${item.name} from wishlist`}
+                  >
+                    <X size={12} style={{ color: "rgba(239,68,68,0.7)" }} />
+                  </motion.button>
+                </div>
               </motion.div>
             ))}
           </AnimatePresence>

--- a/src/components/WishlistSidebar.tsx
+++ b/src/components/WishlistSidebar.tsx
@@ -4,11 +4,20 @@ import Image from "next/image";
 import { motion, AnimatePresence } from "framer-motion";
 import { X, Heart } from "lucide-react";
 import { useWishlist } from "@/context/WishlistContext";
+import { useCart } from "@/context/CartContext";
 import SideDrawer from "@/components/SideDrawer";
 import { ease } from "@/lib/motion";
 
 export default function WishlistSidebar() {
   const { items, wishlistOpen, setWishlistOpen, toggleItem } = useWishlist();
+  const { addItem, setCartOpen } = useCart();
+
+  // Move every saved item into the bag, then hand off to the cart.
+  const handleShopAll = () => {
+    items.forEach((item) => addItem(item));
+    setWishlistOpen(false);
+    setCartOpen(true);
+  };
 
   return (
     <SideDrawer
@@ -23,6 +32,7 @@ export default function WishlistSidebar() {
           <motion.button
             whileHover={{ scale: 1.015, opacity: 0.92 }}
             whileTap={{ scale: 0.98 }}
+            onClick={handleShopAll}
             className="w-full py-4 rounded-full text-white font-semibold text-[11px] tracking-[0.13em] uppercase"
             style={{
               background: "#c9977a",

--- a/src/context/WishlistContext.tsx
+++ b/src/context/WishlistContext.tsx
@@ -25,6 +25,7 @@ interface WishlistContextType {
   setWishlistOpen: (open: boolean) => void;
   toggleItem: (product: WishlistProduct) => void;
   isWishlisted: (id: string) => boolean;
+  clearWishlist: () => void;
 }
 
 const WishlistContext = createContext<WishlistContextType | null>(null);
@@ -72,9 +73,11 @@ export function WishlistProvider({ children }: { children: ReactNode }) {
 
   const isWishlisted = (id: string) => items.some((p) => p.id === id);
 
+  const clearWishlist = () => setItems([]);
+
   return (
     <WishlistContext.Provider
-      value={{ items, wishlistOpen, setWishlistOpen, toggleItem, isWishlisted }}
+      value={{ items, wishlistOpen, setWishlistOpen, toggleItem, isWishlisted, clearWishlist }}
     >
       {children}
     </WishlistContext.Provider>
@@ -90,6 +93,7 @@ export function useWishlist() {
       setWishlistOpen: (_: boolean) => {},
       toggleItem: (_: WishlistProduct) => {},
       isWishlisted: (_: string) => false,
+      clearWishlist: () => {},
     };
   }
   return ctx;

--- a/src/context/WishlistContext.tsx
+++ b/src/context/WishlistContext.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { createContext, useContext, useState, type ReactNode } from "react";
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from "react";
+
+const STORAGE_KEY = "hb-wishlist";
 
 export interface WishlistProduct {
   /** Namespaced key, e.g. "product:1" — matches the cart's id scheme. */
@@ -24,6 +32,35 @@ const WishlistContext = createContext<WishlistContextType | null>(null);
 export function WishlistProvider({ children }: { children: ReactNode }) {
   const [items, setItems] = useState<WishlistProduct[]>([]);
   const [wishlistOpen, setWishlistOpen] = useState(false);
+  // Gate persistence until the stored wishlist has loaded, so the initial empty
+  // state doesn't overwrite it. Starting empty also keeps SSR/first render in
+  // sync (no hydration mismatch) — the restored wishlist applies after mount.
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (raw) {
+        // Keep only string-id entries (guards against legacy/corrupt data).
+        const restored = (JSON.parse(raw) as WishlistProduct[]).filter(
+          (p) => typeof p.id === "string"
+        );
+        setItems(restored);
+      }
+    } catch {
+      // Corrupt/unavailable storage — start with an empty wishlist.
+    }
+    setLoaded(true);
+  }, []);
+
+  useEffect(() => {
+    if (!loaded) return;
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+    } catch {
+      // Storage full / unavailable — non-fatal.
+    }
+  }, [items, loaded]);
 
   const toggleItem = (product: WishlistProduct) => {
     setItems((prev) =>


### PR DESCRIPTION
## Summary

Issue #6 (Wishlist Sidebar) already met all 5 acceptance criteria (opens from navbar, displays liked products, remove, empty state, mobile responsive — via the shared glassmorphism `SideDrawer`). This PR closes the quality gaps beyond the criteria and adds wishlist→cart move semantics.

### Changes
- **Persistence** (`src/context/WishlistContext.tsx`) — wishlist now saved to `localStorage` (`hb-wishlist`), mirroring the cart: hydration-gated load/save effects with a string-id filter on restore. Survives refresh; the navbar badge restores.
- **Move semantics** (`src/components/WishlistSidebar.tsx`) — "Shop All Saved Items" now *moves* everything: adds all to the bag, **clears the wishlist** (new `clearWishlist()`), and opens the cart.
- **Per-item move** — each wishlist row has a "Move to bag" button beside remove: adds that one item to the cart and removes it from the wishlist. Single moves don't auto-open the cart (the "Added to bag" toast confirms), matching the product-card add behaviour.
- **Mobile menu** (`src/components/Navbar.tsx`) — added Wishlist + Bag entries to the hamburger menu for parity with the desktop icon row.

### Commits
- `3a704fa` — persistence, footer CTA, mobile menu triggers
- `ac5a7fd` — move-to-bag semantics + per-item move

## Verification
- `tsc --noEmit` clean.
- `next build` passes (all routes prerender) from the correctly-cased path (see #24).
- Interactive flows (persist-across-refresh, per-item move, Shop-All clear + cart open, mobile triggers) are client-side — best confirmed with a quick browser pass.

Closes #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)