### PR TITLE
chore: use h-svh for hero so bottom CTAs clear iOS Safari URL bar (#55)

### DIFF
--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -130,7 +130,7 @@ export default function Hero({ onVideoReady, startEntrance = true }: HeroProps) 
   return (
     <section
       ref={ref}
-      className="relative w-full h-screen min-h-[700px] overflow-hidden bg-[#1e1814]"
+      className="relative w-full h-svh min-h-[700px] overflow-hidden bg-[#1e1814]"
     >
       {/* Video background */}
       <motion.div


### PR DESCRIPTION
## What

Change the hero section height from `h-screen` (`100vh`) to `h-svh` (small viewport height).

`src/components/sections/Hero.tsx`:
```diff
- className="relative w-full h-screen min-h-[700px] overflow-hidden bg-[#1e1814]"
+ className="relative w-full h-svh   min-h-[700px] overflow-hidden bg-[#1e1814]"
```

## Why

On mobile Safari, `100vh` measures the viewport **with the URL bar hidden**, so on first paint — when the bar is showing — the section overshoots the visible area. The hero is bottom-anchored (`justify-end`, `pb-20 md:pb-28`, `absolute bottom-8` scroll indicator), so its only interactive affordances — the CTA row and the "Scroll" indicator — were pushed underneath the URL bar and became unreachable at load.

`svh` (not `dvh`): `svh` is the small viewport height — stable, and it does **not** resize as the URL bar shows/hides. `dvh` would shift content during scroll. Browsers without `svh` support fall back to `min-h-[700px]`, so the worst case is "700px tall", never "collapsed". Tailwind 3.4 supports `h-svh` natively — no config change needed.

## Verification

- ✅ `npm run build` compiles clean.
- ⏳ **Manual (the real acceptance test):** needs verification on a real iOS device / Simulator (Safari) — Chrome DevTools device emulation uses a fixed viewport with no dynamic URL bar and will not reproduce the bug. Confirm CTAs + scroll indicator fully visible at first paint (URL bar showing), no layout shift while scrolling, desktop unchanged.

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)