### PR TITLE
chore: wire CSP nonce through HomeHero loader script/style (Report-Only) (#46)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,15 +10,20 @@ import Testimonials from "@/components/sections/Testimonials";
 import Reviews from "@/components/sections/Reviews";
 import Newsletter from "@/components/sections/Newsletter";
 import Footer from "@/components/Footer";
+import { headers } from "next/headers";
 import { getFeaturedProducts } from "@/lib/shopify";
 
 export default async function Home() {
-  const products = await getFeaturedProducts(); 
+  const products = await getFeaturedProducts();
+  // #46: nonce minted per request in proxy.ts, threaded into HomeHero's inline
+  // loader script. Reading it opts this page into dynamic rendering — inherent to
+  // per-request nonces.
+  const nonce = (await headers()).get("x-nonce") ?? undefined;
   return (
     <ClientWrapper>
       <main data-site-root>
         <Navbar />
-        <HomeHero />
+        <HomeHero nonce={nonce} />
         <BrandStory />
         <FeaturedProducts products={products} />
         <Bundles />

--- a/src/components/sections/HomeHero.tsx
+++ b/src/components/sections/HomeHero.tsx
@@ -25,9 +25,12 @@ let shownThisSpaSession = false;
 // Runs during HTML parse, before first paint — hides the SSR'd loader on
 // repeat visits so it never flashes. Injects a <style> rather than touching
 // React-managed attributes (a class on <html> triggers a hydration mismatch).
-const skipScript = `try{if(sessionStorage.getItem("${LOADER_SESSION_KEY}")){var s=document.createElement("style");s.textContent="[data-page-loader]{display:none!important}";document.head.appendChild(s)}}catch(e){}`;
+// #46: the injected <style> copies this script's own CSP nonce (via
+// document.currentScript.nonce, which survives the DOM's post-parse nonce
+// hiding) so it stays allowed once the CSP is enforced with a strict style-src.
+const skipScript = `try{if(sessionStorage.getItem("${LOADER_SESSION_KEY}")){var s=document.createElement("style");s.textContent="[data-page-loader]{display:none!important}";var n=document.currentScript&&document.currentScript.nonce;if(n)s.setAttribute("nonce",n);document.head.appendChild(s)}}catch(e){}`;
 
-export default function HomeHero() {
+export default function HomeHero({ nonce }: { nonce?: string }) {
   // false at hydration (matches SSR), true on fresh SPA re-mounts.
   const [skipped, setSkipped] = useState(() => shownThisSpaSession);
   const [videoReady, setVideoReady] = useState(false);
@@ -84,7 +87,17 @@ export default function HomeHero() {
   // remount would restart the video).
   return (
     <>
-      {!skipped && <script dangerouslySetInnerHTML={{ __html: skipScript }} />}
+      {!skipped && (
+        // suppressHydrationWarning: browsers blank the nonce content attribute
+        // after using it for the CSP check, so the hydrating DOM reads nonce=""
+        // while SSR emitted the real value — an expected, benign divergence. The
+        // script already ran at parse time; hydration never re-executes it.
+        <script
+          nonce={nonce}
+          suppressHydrationWarning
+          dangerouslySetInnerHTML={{ __html: skipScript }}
+        />
+      )}
       <AnimatePresence
         onExitComplete={() => {
           // Loader's slide-up has finished — now release the lock/inert. On

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -11,35 +11,81 @@ const PROTECTED = ["/account", "/checkout"];
 // authenticated-but-unverified users still need it).
 const AUTH_PAGES = ["/login", "/signup", "/forgot-password"];
 
+/**
+ * #46: per-request Content-Security-Policy with a nonce.
+ *
+ * Shipped **Report-Only** for now — it reports violations but blocks nothing, so
+ * it can't break auth or animations while the directives are tuned from real
+ * reports before a future flip to enforcing. HomeHero's inline loader script (and
+ * the <style> it injects) read the nonce so the no-flash behavior survives that flip.
+ *
+ * `style-src` deliberately stays on 'unsafe-inline' with no nonce token: Framer
+ * Motion, React style={{}}, next/font and optimizeCss all emit inline styles, and
+ * per spec a nonce in a directive makes browsers ignore 'unsafe-inline'.
+ */
+function buildCsp(nonce: string): string {
+  return [
+    `default-src 'self'`,
+    `script-src 'self' 'nonce-${nonce}' https://apis.google.com https://accounts.google.com https://www.gstatic.com`,
+    `style-src 'self' 'unsafe-inline'`,
+    `img-src 'self' data: blob: https://cdn.shopify.com https://*.googleusercontent.com`,
+    `font-src 'self' data:`,
+    `connect-src 'self' https://*.googleapis.com https://*.firebaseapp.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com`,
+    `frame-src 'self' https://*.firebaseapp.com https://accounts.google.com https://appleid.apple.com`,
+    `media-src 'self'`,
+    `object-src 'none'`,
+    `base-uri 'self'`,
+    `form-action 'self'`,
+    `frame-ancestors 'none'`,
+  ].join("; ");
+}
+
 export function proxy(request: NextRequest) {
   const hasAuth = Boolean(request.cookies.get(AUTH_COOKIE));
   const { pathname } = request.nextUrl;
 
+  const nonce = crypto.randomUUID();
+  const csp = buildCsp(nonce);
+
+  // Forward the nonce + policy to the render via request headers: Next reads the
+  // (request-only) `content-security-policy` header to auto-nonce its own bootstrap
+  // scripts, and `page.tsx` reads `x-nonce` to nonce HomeHero's inline script.
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set("x-nonce", nonce);
+  requestHeaders.set("content-security-policy", csp);
+
   const isProtected = PROTECTED.some((p) => pathname.startsWith(p));
   const isAuthPage = AUTH_PAGES.some((p) => pathname.startsWith(p));
+
+  // Every branch returns through here so the browser-facing Report-Only header
+  // rides along on redirects as well as normal responses.
+  const withCsp = (response: NextResponse) => {
+    response.headers.set("content-security-policy-report-only", csp);
+    return response;
+  };
 
   // Gate protected routes behind a session.
   if (isProtected && !hasAuth) {
     const url = request.nextUrl.clone();
     url.pathname = "/login";
     url.searchParams.set("from", pathname);
-    return NextResponse.redirect(url);
+    return withCsp(NextResponse.redirect(url));
   }
 
   // Keep signed-in users out of the auth screens.
   if (isAuthPage && hasAuth) {
-    return NextResponse.redirect(new URL("/account", request.url));
+    return withCsp(NextResponse.redirect(new URL("/account", request.url)));
   }
 
-  return NextResponse.next();
+  return withCsp(NextResponse.next({ request: { headers: requestHeaders } }));
 }
 
 export const config = {
+  // Run on every page so the CSP is site-wide, excluding API routes and static
+  // assets (anything with a file extension, _next internals, favicon).
   matcher: [
-    "/account/:path*",
-    "/checkout/:path*",
-    "/login",
-    "/signup",
-    "/forgot-password",
+    {
+      source: "/((?!api|_next/static|_next/image|favicon.ico|.*\\..*).*)",
+    },
   ],
 };


### PR DESCRIPTION
## What

Rolls out a **`Content-Security-Policy-Report-Only`** header with a per-request nonce and threads that nonce through `HomeHero`'s inline loader `<script>` and the `<style>` it injects — closing #46.

Report-Only reports violations but **blocks nothing**, so there's zero risk to auth or animations. It establishes the nonce path so the loader's no-flash-on-repeat-visit behavior survives a future flip to an enforced CSP.

## Changes

- **`src/proxy.ts`** — mint a per-request nonce, build the policy, set it `Content-Security-Policy-Report-Only` on every response (redirects included), and forward the nonce via **request** headers so Next auto-nonces its own bootstrap scripts and `page.tsx` can read `x-nonce`. Matcher broadened so the CSP is **site-wide** (API routes + static assets excluded).
- **`src/app/page.tsx`** (Server Component) — read `x-nonce` via `next/headers` and pass it to `<HomeHero nonce={…} />`. This opts the home page into **dynamic rendering** (`ƒ`), which is inherent to per-request nonces.
- **`src/components/sections/HomeHero.tsx`** — nonce the inline `<script>`; `skipScript` copies the script's own nonce onto the injected `<style>` via `document.currentScript.nonce`. `suppressHydrationWarning` silences the expected nonce divergence (browsers blank the nonce attribute after the CSP check, so the hydrating DOM reads `nonce=""`).

## Design notes

- **`style-src` stays `'unsafe-inline'`** with no nonce token — Framer Motion, React `style={{}}`, next/font and `optimizeCss` all emit inline styles, and per spec a nonce in a directive makes browsers *ignore* `'unsafe-inline'`. The injected `<style>` still carries a nonce (harmless now, correct under a future strict `style-src-elem`).
- The directive list is a **tunable starting point**. Report-Only is exactly for observing real violations (auth popups, Shopify, etc.) before enforcing — a follow-up flips it to enforced and can add a `report-to` sink.

## Verification (dev + build)

- ✅ `npm run build` clean; `/` now renders `ƒ (Dynamic)`.
- ✅ Response carries `Content-Security-Policy-Report-Only` with a fresh nonce; HomeHero's `<script nonce>` **matches** the header nonce; all 38 script tags share that one nonce (Next auto-nonce working).
- ✅ On repeat visit the injected `[data-page-loader]{display:none}` `<style>` inherits the nonce (IDL) and the loader stays hidden — **no flash**.
- ✅ No hydration mismatch; no CSP violations on the home-page load (only the pre-existing, expected Shopify 401).

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)