### PR TITLE
feat: development product catalogue behind an env switch (#68)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,23 @@ NEXT_PUBLIC_FIREBASE_APP_ID=
 NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN=
 NEXT_PUBLIC_SHOPIFY_STOREFRONT_TOKEN=
 
+# Development product catalogue (#68). Lets the storefront be built and reviewed
+# before the Shopify catalogue is populated.
+#
+#   true   -> development mode: serve src/lib/placeholder-products.ts
+#   false  -> production mode: serve the real Shopify catalogue
+#   unset  -> production mode (safe default)
+#
+# ONLY the exact string "true" enables it. Anything else — false, TRUE, 1, a typo,
+# or nothing at all — uses Shopify, so a mistake can never ship fake products.
+#
+# NEXT_PUBLIC_* values are inlined at BUILD time, not read at runtime. Changing
+# this in Netlify therefore requires a NEW BUILD; redeploying an existing one
+# keeps the old value baked in.
+#
+# Production must be `false` or unset.
+NEXT_PUBLIC_USE_PLACEHOLDER_PRODUCTS=false
+
 # Shopify webhook signing secret, used to verify the HMAC on POST /api/revalidate.
 # Shopify admin → Settings → Notifications → Webhooks, "Your webhooks are signed
 # with this secret" at the bottom of the page. This is NOT a value you invent.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,20 @@ For non-feature work substitute the type segment: `fix`, `chore`, `refactor`, `d
   Webhooks, not one you invent. Unset fails closed with 503. Use
   `revalidateTag("products", { expire: 0 })`, **not** the `"max"` profile — `"max"` sets
   expiry a year out and only marks the tag stale, so the next shopper still gets the old price.
+- **Development catalogue** (#68): `NEXT_PUBLIC_USE_PLACEHOLDER_PRODUCTS=true` serves
+  `src/lib/placeholder-products.ts` instead of Shopify, so the storefront can be built before
+  the catalogue is populated. **Only the exact string `true`** enables it — `false`, a typo or
+  unset all mean Shopify, and the flag is inlined at *build* time, so flipping it on Netlify
+  needs a new build. `getProducts`/`getProductBySlug` both honour it (so home, store and
+  `/store/[slug]` agree); the module is loaded via `import()` inside the guarded branch, which
+  keeps it out of the production bundle and breaks the import cycle with `shopify.ts`.
+  ⚠️ Don't confuse it with `ShopifyProduct.placeholder`, which means a *non-purchasable*
+  "Coming Soon" tile for an unconfigured store — development products must never set it.
+- **Featured showcase** (#68): marked by the plain Shopify tag `featured` (`FEATURED_TAG`), so
+  merchandisers control it from admin with no deploy. `getShowcaseProducts()` takes tagged
+  products first, then tops up in catalogue order (`BEST_SELLING` for Shopify) — deterministic,
+  never random. Cards render `displayTags()`, which strips the marker; `toProduct` keeps the raw
+  tag list whole because the 3-tag cap is a card concern.
 - **Prices always go through `formatPrice`** (`src/lib/format.ts`) — never construct an
   `Intl.NumberFormat` in a component. It renders `R 54` for whole amounts and `R 54,99`
   when there are cents; three divergent copies once made one screen show both `R 68` and

--- a/src/app/store/StoreContent.tsx
+++ b/src/app/store/StoreContent.tsx
@@ -6,7 +6,7 @@ import { fadeUp, staggerContainer, staggerContainerSlow } from "@/lib/motion";
 import { bundles } from "@/lib/products";
 import ShopifyProductCard from "@/components/ShopifyProductCard";
 import BundleCard from "@/components/BundleCard";
-import type { ShopifyProduct } from "@/lib/shopify";
+import type { ShopifyProduct } from "@/lib/product";
 
 export default function StoreContent({ products }: { products: ShopifyProduct[] }) {
   const bundlesRef = useRef<HTMLDivElement>(null);

--- a/src/app/store/[slug]/ProductDetailContent.tsx
+++ b/src/app/store/[slug]/ProductDetailContent.tsx
@@ -10,7 +10,7 @@ import { formatPrice } from "@/lib/format";
 import { useCart } from "@/context/CartContext";
 import { useWishlist } from "@/context/WishlistContext";
 import ShopifyProductCard from "@/components/ShopifyProductCard";
-import { defaultVariant, isSoldOut, toCartItem, type ShopifyProduct } from "@/lib/shopify";
+import { defaultVariant, isSoldOut, toCartItem, type ShopifyProduct } from "@/lib/product";
 
 function Stars({ rating, size = 13 }: { rating: number; size?: number }) {
   return (

--- a/src/app/store/[slug]/page.tsx
+++ b/src/app/store/[slug]/page.tsx
@@ -2,7 +2,8 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
-import { getProducts, getProductBySlug, getRelatedProducts } from "@/lib/shopify";
+import { getProducts, getProductBySlug } from "@/lib/shopify";
+import { getRelatedProducts } from "@/lib/product";
 import ProductDetailContent from "./ProductDetailContent";
 
 export async function generateStaticParams() {

--- a/src/components/ShopifyProductCard.tsx
+++ b/src/components/ShopifyProductCard.tsx
@@ -10,7 +10,7 @@ import { cn } from "@/lib/utils";
 import { useWishlist } from "@/context/WishlistContext";
 import { useCart } from "@/context/CartContext";
 import { formatPrice } from "@/lib/format";
-import { isSoldOut, toCartItem, type ShopifyProduct } from "@/lib/shopify";
+import { displayTags, isSoldOut, toCartItem, type ShopifyProduct } from "@/lib/shopify";
 
 
 function WishlistHeart({ product }: { product: ShopifyProduct }) {
@@ -141,6 +141,7 @@ export default function ShopifyProductCard({
   const { addItem } = useCart();
 
   const soldOut = isSoldOut(product);
+  const tags = displayTags(product);
   // Placeholders have no Shopify variant to buy; sold-out products have none in
   // stock. Both keep the card's imagery but lose every purchase control.
   const purchasable = !product.placeholder && !soldOut;
@@ -264,10 +265,11 @@ export default function ShopifyProductCard({
           )}
         </AnimatePresence>
 
-        {/* Tags row */}
-        {product.tags.length > 0 && (
+        {/* Tags row — `displayTags` drops the `featured` merchandising marker and
+            caps the list; the raw tags stay whole on the product for selection. */}
+        {tags.length > 0 && (
           <div className="absolute bottom-0 left-0 right-0 p-4 flex gap-1.5">
-            {product.tags.map((tag) => (
+            {tags.map((tag) => (
               <span
                 key={tag}
                 className="px-2 py-0.5 rounded-full text-white/80 text-[8px] tracking-[0.1em] uppercase"

--- a/src/components/ShopifyProductCard.tsx
+++ b/src/components/ShopifyProductCard.tsx
@@ -10,7 +10,7 @@ import { cn } from "@/lib/utils";
 import { useWishlist } from "@/context/WishlistContext";
 import { useCart } from "@/context/CartContext";
 import { formatPrice } from "@/lib/format";
-import { displayTags, isSoldOut, toCartItem, type ShopifyProduct } from "@/lib/shopify";
+import { displayTags, isSoldOut, toCartItem, type ShopifyProduct } from "@/lib/product";
 
 
 function WishlistHeart({ product }: { product: ShopifyProduct }) {

--- a/src/components/sections/FeaturedProducts.tsx
+++ b/src/components/sections/FeaturedProducts.tsx
@@ -4,7 +4,7 @@ import { useRef } from "react";
 import { motion, useInView } from "framer-motion";
 import { fadeUp, staggerContainer, staggerContainerSlow } from "@/lib/motion";
 import ShopifyProductCard from "@/components/ShopifyProductCard";
-import type { ShopifyProduct } from "@/lib/shopify";
+import type { ShopifyProduct } from "@/lib/product";
 
 export default function FeaturedProducts({ products }: { products: ShopifyProduct[] }) {
   const ref = useRef<HTMLDivElement>(null);

--- a/src/lib/placeholder-products.ts
+++ b/src/lib/placeholder-products.ts
@@ -1,0 +1,297 @@
+// Development product catalogue (issue #68).
+//
+// Used ONLY when NEXT_PUBLIC_USE_PLACEHOLDER_PRODUCTS === "true", via the single
+// guarded branch in `src/lib/shopify.ts`. Nothing else may import this module —
+// keeping it to one import site is what stops development data reaching
+// production. See `usePlaceholderCatalogue()` there.
+//
+// ─────────────────────────────────────────────────────────────────────────────
+// DO NOT SET `placeholder: true` ON ANYTHING IN THIS FILE.
+//
+// `ShopifyProduct.placeholder` means something else entirely: a non-purchasable
+// "Coming Soon" tile shown when the store has no credentials at all, which
+// ShopifyProductCard uses to strip every purchase control. These products are the
+// opposite — fake data that must behave EXACTLY like real Shopify products so the
+// storefront components get genuinely exercised. Two different ideas, unhappily
+// similar names.
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// The catalogue is deliberately awkward, not a happy path: it carries sold-out
+// stock, single- and multi-variant products, discounts and full prices, missing
+// ratings, missing badges, and long names that test card typography. Anything the
+// real storefront can encounter should be representable here.
+
+import { FEATURED_TAG, type ShopifyProduct } from "./shopify";
+
+/**
+ * Ids sit in a 9000 block so a development product is obvious on sight in a cart
+ * key, a URL, or a log line. Real Shopify product ids are far larger.
+ */
+export const placeholderCatalogue: ShopifyProduct[] = [
+  {
+    id: "product:9001",
+    slug: "glow-collagen-blend",
+    name: "Glow Collagen Blend",
+    category: "Beauty",
+    description:
+      "Marine collagen peptides with vitamin C and biotin, blended for skin that looks rested and hair that feels stronger. Stir into coffee, smoothies or simply water.",
+    price: 549,
+    originalPrice: 689,
+    image: "/images/item-1.jpeg",
+    gallery: ["/images/item-1.jpeg", "/images/item-3.jpeg"],
+    tags: [FEATURED_TAG, "Skin", "Hair", "Nails"],
+    rating: 4.9,
+    reviews: 128,
+    variants: [
+      { id: "90011", label: "30 servings", price: 549, originalPrice: 689, availableForSale: true },
+      { id: "90012", label: "60 servings", price: 949, originalPrice: 1199, availableForSale: true },
+    ],
+  },
+  {
+    id: "product:9002",
+    slug: "hey-beautiful-plant-protein",
+    name: "Hey Beautiful Plant Protein",
+    category: "Protein",
+    description:
+      "A complete plant protein from pea and brown rice, 24g per serving, with digestive enzymes so it sits light. No chalk, no bloat.",
+    price: 649,
+    originalPrice: null,
+    image: "/images/item-2.jpeg",
+    gallery: ["/images/item-2.jpeg", "/images/item-5.jpeg"],
+    tags: [FEATURED_TAG, "Protein", "Vegan"],
+    rating: 4.8,
+    reviews: 94,
+    variants: [
+      { id: "90021", label: "Vanilla Bean", price: 649, originalPrice: null, availableForSale: true },
+      { id: "90022", label: "Cacao", price: 649, originalPrice: null, availableForSale: true },
+      { id: "90023", label: "Berry", price: 649, originalPrice: null, availableForSale: false },
+    ],
+  },
+  {
+    id: "product:9003",
+    slug: "morning-glow-ritual",
+    name: "Morning Glow Ritual",
+    category: "Wellness",
+    description:
+      "Greens, adaptogens and B-vitamins for a start that feels steady rather than spiked. Designed to be the first thing you reach for.",
+    price: 429,
+    originalPrice: 519,
+    image: "/images/item-3.jpeg",
+    gallery: ["/images/item-3.jpeg", "/images/item-1.jpeg"],
+    tags: [FEATURED_TAG, "Energy", "Focus"],
+    rating: 4.7,
+    reviews: 62,
+    badge: "Bestseller",
+    variants: [
+      { id: "90031", label: "Morning Glow Ritual", price: 429, originalPrice: 519, availableForSale: true },
+    ],
+  },
+  {
+    id: "product:9004",
+    slug: "deep-recovery-magnesium-complex",
+    // Deliberately long — checks card title wrapping at every breakpoint.
+    name: "Deep Recovery Magnesium Complex with Ashwagandha",
+    category: "Recovery",
+    description:
+      "Magnesium glycinate and ashwagandha to ease the body down at the end of the day. Take an hour before bed.",
+    price: 389,
+    originalPrice: null,
+    image: "/images/item-4.jpeg",
+    gallery: ["/images/item-4.jpeg", "/images/item-2.jpeg"],
+    tags: [FEATURED_TAG, "Sleep", "Calm"],
+    rating: 4.9,
+    reviews: 210,
+    variants: [
+      { id: "90041", label: "Deep Recovery Magnesium Complex", price: 389, originalPrice: null, availableForSale: true },
+    ],
+  },
+  {
+    id: "product:9005",
+    slug: "radiance-marine-collagen",
+    name: "Radiance Marine Collagen",
+    category: "Beauty",
+    description:
+      "Our highest-concentration marine collagen. The trial size is popular and goes out of stock often — the full size is the better value anyway.",
+    price: 399,
+    // Product-level compare-at describes the CHEAPEST variant, which has no
+    // discount — so this is null even though a pricier variant IS discounted.
+    // That divergence is the whole point of this product: see the note below.
+    originalPrice: null,
+    image: "/images/item-5.jpeg",
+    gallery: ["/images/item-5.jpeg", "/images/item-4.jpeg"],
+    tags: ["Skin", "Glow"],
+    variants: [
+      // The cheapest variant is sold out, so `defaultVariant()` skips it and
+      // selects the R749 one — which IS discounted. Before #62's per-variant
+      // `compareAtPrice` fix the strikethrough silently vanished here, because the
+      // detail page compared against the product-level range above. The real
+      // Shopify catalogue still has no product that reproduces this.
+      { id: "90051", label: "Trial · 14 servings", price: 399, originalPrice: null, availableForSale: false },
+      { id: "90052", label: "Full · 60 servings", price: 749, originalPrice: 899, availableForSale: true },
+    ],
+  },
+  {
+    id: "product:9006",
+    slug: "everyday-multivitamin",
+    name: "Everyday Multivitamin",
+    category: "Supplements",
+    description:
+      "The unglamorous one that quietly does the work. A full-spectrum daily multivitamin with iron and folate.",
+    price: 299,
+    originalPrice: null,
+    image: "/images/item-1.jpeg",
+    gallery: ["/images/item-1.jpeg", "/images/item-2.jpeg"],
+    tags: ["Daily", "Essentials"],
+    rating: 4.6,
+    reviews: 340,
+    variants: [
+      { id: "90061", label: "Everyday Multivitamin", price: 299, originalPrice: null, availableForSale: true },
+    ],
+  },
+  {
+    // Short name, no rating, no badge, no discount — the plainest card state.
+    id: "product:9007",
+    slug: "calm",
+    name: "Calm",
+    category: "Wellness",
+    description:
+      "L-theanine and lemon balm for the middle of a long day. Not a sedative — it takes the edge off without dulling anything.",
+    price: 249,
+    originalPrice: null,
+    image: "/images/item-3.jpeg",
+    gallery: ["/images/item-3.jpeg", "/images/item-5.jpeg"],
+    tags: ["Calm"],
+    variants: [
+      { id: "90071", label: "Calm", price: 249, originalPrice: null, availableForSale: true },
+    ],
+  },
+  {
+    id: "product:9008",
+    slug: "sleep-and-restore-botanical-blend",
+    name: "Sleep & Restore Botanical Blend",
+    category: "Recovery",
+    description:
+      "Valerian, passionflower and magnesium in a warm night-time blend. Steep it, drink it, sleep.",
+    price: 459,
+    originalPrice: 549,
+    image: "/images/item-4.jpeg",
+    gallery: ["/images/item-4.jpeg", "/images/item-3.jpeg"],
+    tags: ["Sleep", "Night"],
+    rating: 4.8,
+    reviews: 88,
+    variants: [
+      { id: "90081", label: "Sleep & Restore Botanical Blend", price: 459, originalPrice: 549, availableForSale: true },
+    ],
+  },
+  {
+    // Every variant unavailable → isSoldOut() true → Sold Out pill, no controls.
+    id: "product:9009",
+    slug: "iron-b12-support",
+    name: "Iron + B12 Support",
+    category: "Supplements",
+    description:
+      "Gentle chelated iron with B12 and vitamin C for absorption. Restocking shortly.",
+    price: 279,
+    originalPrice: null,
+    image: "/images/item-2.jpeg",
+    gallery: ["/images/item-2.jpeg", "/images/item-1.jpeg"],
+    tags: ["Iron", "Energy"],
+    rating: 4.7,
+    reviews: 71,
+    variants: [
+      { id: "90091", label: "60 capsules", price: 279, originalPrice: null, availableForSale: false },
+      { id: "90092", label: "120 capsules", price: 499, originalPrice: null, availableForSale: false },
+    ],
+  },
+  {
+    // Cents — exercises formatPrice's "R 219,99" branch, which the real
+    // catalogue had no product to test until recently.
+    id: "product:9010",
+    slug: "hydration-electrolyte-sachets",
+    name: "Hydration Electrolyte Sachets",
+    category: "Wellness",
+    description:
+      "Sodium, potassium and magnesium without the sugar load. One sachet in 500ml of water.",
+    price: 219.99,
+    originalPrice: null,
+    image: "/images/item-5.jpeg",
+    gallery: ["/images/item-5.jpeg", "/images/item-3.jpeg"],
+    tags: ["Hydration", "Training"],
+    rating: 4.5,
+    reviews: 51,
+    variants: [
+      { id: "90101", label: "Citrus · 14 sachets", price: 219.99, originalPrice: null, availableForSale: true },
+      { id: "90102", label: "Berry · 14 sachets", price: 219.99, originalPrice: null, availableForSale: true },
+    ],
+  },
+  {
+    id: "product:9011",
+    slug: "beauty-sleep-silk-complex",
+    name: "Beauty Sleep Silk Complex",
+    category: "Beauty",
+    description:
+      "An overnight blend of silk protein peptides and hyaluronic acid, taken rather than applied.",
+    price: 599,
+    originalPrice: null,
+    image: "/images/item-1.jpeg",
+    gallery: ["/images/item-1.jpeg", "/images/item-4.jpeg"],
+    tags: ["Overnight", "Skin"],
+    badge: "New",
+    variants: [
+      { id: "90111", label: "Beauty Sleep Silk Complex", price: 599, originalPrice: null, availableForSale: true },
+    ],
+  },
+  {
+    id: "product:9012",
+    slug: "pre-workout-bloom",
+    name: "Pre-Workout Bloom",
+    category: "Protein",
+    description:
+      "Beetroot, citrulline and a modest 90mg of green-tea caffeine. Enough to start, not enough to jitter.",
+    price: 479,
+    originalPrice: 559,
+    image: "/images/item-2.jpeg",
+    gallery: ["/images/item-2.jpeg", "/images/item-4.jpeg"],
+    tags: ["Training", "Energy"],
+    rating: 4.4,
+    reviews: 37,
+    variants: [
+      { id: "90121", label: "Pink Grapefruit", price: 479, originalPrice: 559, availableForSale: true },
+      { id: "90122", label: "Watermelon", price: 479, originalPrice: 559, availableForSale: true },
+    ],
+  },
+  {
+    id: "product:9013",
+    slug: "greens-and-glow-daily-powder",
+    name: "Greens & Glow Daily Powder",
+    category: "Supplements",
+    description:
+      "Spirulina, wheatgrass and spinach with a mint finish so it actually tastes of something you'd choose.",
+    price: 519,
+    originalPrice: null,
+    image: "/images/item-3.jpeg",
+    gallery: ["/images/item-3.jpeg", "/images/item-2.jpeg"],
+    tags: ["Greens", "Daily"],
+    rating: 4.7,
+    reviews: 143,
+    variants: [
+      { id: "90131", label: "Greens & Glow Daily Powder", price: 519, originalPrice: null, availableForSale: true },
+    ],
+  },
+  {
+    id: "product:9014",
+    slug: "rose-recovery-body-butter",
+    name: "Rose Recovery Body Butter",
+    category: "Recovery",
+    description:
+      "Shea and rosehip for post-training skin. The one product here you put on rather than in.",
+    price: 189,
+    originalPrice: null,
+    image: "/images/item-4.jpeg",
+    gallery: ["/images/item-4.jpeg", "/images/item-5.jpeg"],
+    tags: ["Body", "Rose"],
+    variants: [
+      { id: "90141", label: "Rose Recovery Body Butter", price: 189, originalPrice: null, availableForSale: true },
+    ],
+  },
+];

--- a/src/lib/placeholder-products.ts
+++ b/src/lib/placeholder-products.ts
@@ -21,7 +21,7 @@
 // ratings, missing badges, and long names that test card typography. Anything the
 // real storefront can encounter should be representable here.
 
-import { FEATURED_TAG, type ShopifyProduct } from "./shopify";
+import { FEATURED_TAG, type ShopifyProduct } from "./product";
 
 /**
  * Ids sit in a 9000 block so a development product is obvious on sight in a cart

--- a/src/lib/product.ts
+++ b/src/lib/product.ts
@@ -1,0 +1,134 @@
+// The shared product model and the pure helpers around it.
+//
+// Deliberately separate from `shopify.ts`: this module is safe in a client
+// bundle, that one is not. Product cards, the detail page and the store grid all
+// run in the browser and only need the shape plus a few pure functions — they
+// must never pull in the Storefront queries or the development catalogue behind
+// them. Keeping data fetching out of the presentation path is what stops that
+// happening by accident (issue #68).
+//
+// Import rule of thumb:
+//   "use client" component  -> @/lib/product
+//   server page / fetching  -> @/lib/shopify (which re-uses these types)
+
+export interface ShopifyVariant {
+  /** Numeric Shopify variant id — the `#<variantId>` half of the cart key. */
+  id: string;
+  label: string;
+  price: number;
+  /**
+   * This variant's own compare-at price, unlike `ShopifyProduct.originalPrice`
+   * which is the product-level range and only lines up with the cheapest variant.
+   */
+  originalPrice: number | null;
+  availableForSale: boolean;
+}
+
+export interface ShopifyProduct {
+  /** Namespaced cart key, e.g. "product:1" — never a bare number (see CartContext). */
+  id: string;
+  name: string;
+  category: string;
+  price: number;
+  originalPrice: number | null;
+  image: string;
+  tags: string[];
+  /**
+   * "Coming Soon" tile for a store with NO credentials: not purchasable, no cart,
+   * no wishlist, no detail page. NOT related to the development catalogue in
+   * `placeholder-products.ts`, which must never set this — those products are
+   * meant to behave exactly like real ones.
+   */
+  placeholder?: boolean;
+  /** Shopify handle; enables the card's link to `/store/<slug>`. */
+  slug?: string;
+  description?: string;
+  gallery?: string[];
+  variants?: ShopifyVariant[];
+  /** Only present when the store publishes the `reviews` metafields. */
+  rating?: number;
+  reviews?: number;
+  /** Explicit badge label; falls back to a "Sale" badge when `originalPrice` is set. */
+  badge?: string;
+  badgeColor?: string;
+}
+
+/**
+ * Marks a product for the store's featured showcase. A plain Shopify tag, so
+ * merchandisers control the showcase from admin without a deploy, and the
+ * development catalogue marks its picks the same way — one mechanism, both
+ * sources. Filtered out of the tags a card displays (see `displayTags`).
+ */
+export const FEATURED_TAG = "featured";
+
+export function isFeatured(product: ShopifyProduct): boolean {
+  return product.tags.some((t) => t.toLowerCase() === FEATURED_TAG);
+}
+
+/** Tags a card should render: everything except the merchandising marker. */
+export function displayTags(product: ShopifyProduct): string[] {
+  return product.tags.filter((t) => t.toLowerCase() !== FEATURED_TAG).slice(0, 3);
+}
+
+/**
+ * The store's featured showcase, in a stable order — never random, so the same
+ * catalogue always yields the same shelf.
+ *
+ * Tagged products come first. If there aren't enough, it tops up from the rest in
+ * catalogue order, which for Shopify is `sortKey: BEST_SELLING` — a real
+ * merchandising signal rather than an arbitrary API ordering.
+ */
+export function getShowcaseProducts(
+  all: ShopifyProduct[],
+  count = 4
+): ShopifyProduct[] {
+  const tagged = all.filter(isFeatured);
+  if (tagged.length >= count) return tagged.slice(0, count);
+  const rest = all.filter((p) => !isFeatured(p));
+  return [...tagged, ...rest].slice(0, count);
+}
+
+/** Same-category products first, then the rest, capped at 4. */
+export function getRelatedProducts(
+  product: ShopifyProduct,
+  all: ShopifyProduct[]
+): ShopifyProduct[] {
+  const others = all.filter((p) => p.id !== product.id && !p.placeholder);
+  return others
+    .filter((p) => p.category === product.category)
+    .concat(others.filter((p) => p.category !== product.category))
+    .slice(0, 4);
+}
+
+/** The variant a card's quick-add should use: first in stock, else the first. */
+export function defaultVariant(
+  product: ShopifyProduct
+): ShopifyVariant | undefined {
+  return (
+    product.variants?.find((v) => v.availableForSale) ?? product.variants?.[0]
+  );
+}
+
+export function isSoldOut(product: ShopifyProduct): boolean {
+  const variants = product.variants;
+  // A product with no variant data (e.g. a placeholder) isn't "sold out".
+  return !!variants?.length && variants.every((v) => !v.availableForSale);
+}
+
+/**
+ * Builds a cart line for a product/variant pair. Variant-specific lines append
+ * `#<variantId>` to the product key so two sizes of the same product are
+ * distinct rows in the bag (see CartContext).
+ */
+export function toCartItem(product: ShopifyProduct, variant?: ShopifyVariant) {
+  const v = variant ?? defaultVariant(product);
+  const hasChoice = (product.variants?.length ?? 0) > 1;
+
+  return {
+    id: v ? `${product.id}#${v.id}` : product.id,
+    name: hasChoice && v ? `${product.name} — ${v.label}` : product.name,
+    category: product.category,
+    price: v?.price ?? product.price,
+    image: product.image,
+  };
+}

--- a/src/lib/shopify.ts
+++ b/src/lib/shopify.ts
@@ -120,6 +120,60 @@ export interface ShopifyProduct {
   badgeColor?: string;
 }
 
+/**
+ * Marks a product for the store's featured showcase. A plain Shopify tag, so
+ * merchandisers control the showcase from admin without a deploy, and the
+ * development catalogue marks its picks the same way — one mechanism, both
+ * sources. Filtered out of the tags a card displays (see `displayTags`).
+ */
+export const FEATURED_TAG = "featured";
+
+export function isFeatured(product: ShopifyProduct): boolean {
+  return product.tags.some((t) => t.toLowerCase() === FEATURED_TAG);
+}
+
+/** Tags a card should render: everything except the merchandising marker. */
+export function displayTags(product: ShopifyProduct): string[] {
+  return product.tags.filter((t) => t.toLowerCase() !== FEATURED_TAG).slice(0, 3);
+}
+
+/**
+ * The store's featured showcase, in a stable order — never random, so the same
+ * catalogue always yields the same shelf.
+ *
+ * Tagged products come first. If there aren't enough, it tops up from the rest in
+ * catalogue order, which for Shopify is `sortKey: BEST_SELLING` — a real
+ * merchandising signal rather than an arbitrary API ordering.
+ */
+export function getShowcaseProducts(
+  all: ShopifyProduct[],
+  count = 4
+): ShopifyProduct[] {
+  const tagged = all.filter(isFeatured);
+  if (tagged.length >= count) return tagged.slice(0, count);
+  const rest = all.filter((p) => !isFeatured(p));
+  return [...tagged, ...rest].slice(0, count);
+}
+
+/**
+ * Development catalogue switch (#68). ONLY the exact string "true" enables it —
+ * anything else, including unset, means the real Shopify catalogue. Safe by
+ * default, so a missing or misspelled value can never serve fake products.
+ *
+ * `NEXT_PUBLIC_*` is inlined at BUILD time, so this is a compile-time constant:
+ * changing it on Netlify requires a new build, and in production mode the
+ * `import()` below is dead code the bundler drops entirely.
+ */
+function usePlaceholderCatalogue(): boolean {
+  return process.env.NEXT_PUBLIC_USE_PLACEHOLDER_PRODUCTS === "true";
+}
+
+/**
+ * The "Coming Soon" tiles for a store with NO credentials at all. Unrelated to
+ * the development catalogue in `placeholder-products.ts`, despite the name:
+ * `placeholder: true` means non-purchasable, and ShopifyProductCard uses it to
+ * strip every purchase control. Development-catalogue products must never set it.
+ */
 const placeholderProducts: ShopifyProduct[] = [
   { id: "product:1", name: "Glow Collagen Blend", category: "Beauty Support", price: 54, originalPrice: 68, image: "", tags: ["Skin", "Hair", "Nails"], placeholder: true },
   { id: "product:2", name: "Plant Protein Luxe", category: "Performance", price: 62, originalPrice: null, image: "", tags: ["Protein", "Recovery", "Clean"], placeholder: true },
@@ -229,7 +283,9 @@ function toProduct(node: ShopifyProductNode): ShopifyProduct {
     originalPrice: compareAmount > price ? compareAmount : null,
     image: gallery[0] ?? "/images/item-1.jpeg",
     gallery,
-    tags: node.tags.slice(0, 3),
+    // Kept whole: the 3-tag cap is a card concern, and slicing here would drop a
+    // `featured` marker before `isFeatured` ever saw it. See `displayTags`.
+    tags: node.tags,
     variants,
     rating: parseRating(node.rating?.value),
     reviews: node.ratingCount?.value
@@ -240,6 +296,14 @@ function toProduct(node: ShopifyProductNode): ShopifyProduct {
 
 /** The full catalog, best-selling first. Empty when Shopify errors. */
 export async function getProducts(): Promise<ShopifyProduct[]> {
+  // Dynamic so the development catalogue is only ever loaded in development
+  // mode — and, since the flag is inlined at build time, is dropped from the
+  // production bundle altogether. It also breaks the import cycle: that module
+  // imports FEATURED_TAG from this one.
+  if (usePlaceholderCatalogue()) {
+    return (await import("./placeholder-products")).placeholderCatalogue;
+  }
+
   const data = await shopifyFetch<{
     products: { edges: Array<{ node: ShopifyProductNode }> };
   }>(PRODUCTS_QUERY);
@@ -269,6 +333,13 @@ export async function getFeaturedProducts(): Promise<ShopifyProduct[]> {
 export async function getProductBySlug(
   slug: string
 ): Promise<ShopifyProduct | null> {
+  // Must honour the switch too, or every development-catalogue card 404s the
+  // moment someone clicks it.
+  if (usePlaceholderCatalogue()) {
+    const { placeholderCatalogue } = await import("./placeholder-products");
+    return placeholderCatalogue.find((p) => p.slug === slug) ?? null;
+  }
+
   const data = await shopifyFetch<{ product: ShopifyProductNode | null }>(
     PRODUCT_BY_HANDLE_QUERY,
     { handle: slug }

--- a/src/lib/shopify.ts
+++ b/src/lib/shopify.ts
@@ -1,7 +1,14 @@
-// Catalog data layer. Every storefront surface (home featured grid, store grid,
-// product detail) reads products from here, so Shopify is the single source of
-// truth. When the store isn't configured we fall back to non-purchasable
-// placeholders so the site still renders.
+// Catalog data layer — Storefront API fetching. Every storefront surface (home
+// featured grid, store grid, product detail) reads products from here, so Shopify
+// is the single source of truth. When the store isn't configured we fall back to
+// non-purchasable placeholders so the site still renders.
+//
+// SERVER ONLY. The product shape and the pure helpers live in `./product`, which
+// is what client components import. Keeping them apart matters: this module
+// reaches the Storefront queries and the development catalogue, and a client
+// component importing it drags all of that into the browser bundle (#68).
+
+import type { ShopifyProduct, ShopifyVariant } from "./product";
 
 const PRODUCT_FRAGMENT = `
   fragment CatalogProduct on Product {
@@ -81,78 +88,6 @@ interface ShopifyProductNode {
   };
   rating: { value: string } | null;
   ratingCount: { value: string } | null;
-}
-
-export interface ShopifyVariant {
-  /** Numeric Shopify variant id — the `#<variantId>` half of the cart key. */
-  id: string;
-  label: string;
-  price: number;
-  /**
-   * This variant's own compare-at price, unlike `ShopifyProduct.originalPrice`
-   * which is the product-level range and only lines up with the cheapest variant.
-   */
-  originalPrice: number | null;
-  availableForSale: boolean;
-}
-
-export interface ShopifyProduct {
-  /** Namespaced cart key, e.g. "product:1" — never a bare number (see CartContext). */
-  id: string;
-  name: string;
-  category: string;
-  price: number;
-  originalPrice: number | null;
-  image: string;
-  tags: string[];
-  /** Placeholders aren't purchasable: no cart, no wishlist, no detail page. */
-  placeholder?: boolean;
-  /** Shopify handle; enables the card's link to `/store/<slug>`. */
-  slug?: string;
-  description?: string;
-  gallery?: string[];
-  variants?: ShopifyVariant[];
-  /** Only present when the store publishes the `reviews` metafields. */
-  rating?: number;
-  reviews?: number;
-  /** Explicit badge label; falls back to a "Sale" badge when `originalPrice` is set. */
-  badge?: string;
-  badgeColor?: string;
-}
-
-/**
- * Marks a product for the store's featured showcase. A plain Shopify tag, so
- * merchandisers control the showcase from admin without a deploy, and the
- * development catalogue marks its picks the same way — one mechanism, both
- * sources. Filtered out of the tags a card displays (see `displayTags`).
- */
-export const FEATURED_TAG = "featured";
-
-export function isFeatured(product: ShopifyProduct): boolean {
-  return product.tags.some((t) => t.toLowerCase() === FEATURED_TAG);
-}
-
-/** Tags a card should render: everything except the merchandising marker. */
-export function displayTags(product: ShopifyProduct): string[] {
-  return product.tags.filter((t) => t.toLowerCase() !== FEATURED_TAG).slice(0, 3);
-}
-
-/**
- * The store's featured showcase, in a stable order — never random, so the same
- * catalogue always yields the same shelf.
- *
- * Tagged products come first. If there aren't enough, it tops up from the rest in
- * catalogue order, which for Shopify is `sortKey: BEST_SELLING` — a real
- * merchandising signal rather than an arbitrary API ordering.
- */
-export function getShowcaseProducts(
-  all: ShopifyProduct[],
-  count = 4
-): ShopifyProduct[] {
-  const tagged = all.filter(isFeatured);
-  if (tagged.length >= count) return tagged.slice(0, count);
-  const rest = all.filter((p) => !isFeatured(p));
-  return [...tagged, ...rest].slice(0, count);
 }
 
 /**
@@ -346,49 +281,4 @@ export async function getProductBySlug(
   );
 
   return data?.product ? toProduct(data.product) : null;
-}
-
-/** Same-category products first, then the rest, capped at 4. */
-export function getRelatedProducts(
-  product: ShopifyProduct,
-  all: ShopifyProduct[]
-): ShopifyProduct[] {
-  const others = all.filter((p) => p.id !== product.id && !p.placeholder);
-  return others
-    .filter((p) => p.category === product.category)
-    .concat(others.filter((p) => p.category !== product.category))
-    .slice(0, 4);
-}
-
-/** The variant a card's quick-add should use: first in stock, else the first. */
-export function defaultVariant(
-  product: ShopifyProduct
-): ShopifyVariant | undefined {
-  return (
-    product.variants?.find((v) => v.availableForSale) ?? product.variants?.[0]
-  );
-}
-
-export function isSoldOut(product: ShopifyProduct): boolean {
-  const variants = product.variants;
-  // A product with no variant data (e.g. a placeholder) isn't "sold out".
-  return !!variants?.length && variants.every((v) => !v.availableForSale);
-}
-
-/**
- * Builds a cart line for a product/variant pair. Variant-specific lines append
- * `#<variantId>` to the product key so two sizes of the same product are
- * distinct rows in the bag (see CartContext).
- */
-export function toCartItem(product: ShopifyProduct, variant?: ShopifyVariant) {
-  const v = variant ?? defaultVariant(product);
-  const hasChoice = (product.variants?.length ?? 0) > 1;
-
-  return {
-    id: v ? `${product.id}#${v.id}` : product.id,
-    name: hasChoice && v ? `${product.name} — ${v.label}` : product.name,
-    category: product.category,
-    price: v?.price ?? product.price,
-    image: product.image,
-  };
 }


### PR DESCRIPTION
Groundwork for the `/store` redesign. The Shopify catalogue isn't populated — `/store` renders three
products, which is too few to judge any layout against. This adds a local development catalogue
behind an environment switch so the storefront can be finished now and moved onto real products
later without a second redesign.

Closes #68.

## The switch

| `NEXT_PUBLIC_USE_PLACEHOLDER_PRODUCTS` | Source |
| --- | --- |
| `true` | development catalogue |
| `false` | Shopify |
| unset / anything else | Shopify |

Only the exact string `true` enables it, so a typo or a missing value can never serve fake products.
It's honoured in `getProducts` **and** `getProductBySlug`, so the home grid, the store and
`/store/[slug]` never disagree about which catalogue they're looking at — without the second one,
every development card would 404 the moment anyone clicked it.

`NEXT_PUBLIC_*` is inlined at **build** time. Flipping it in Netlify needs a **new build**;
redeploying an existing one keeps the old value baked in.

## The bug this PR found in itself

The first implementation put the entire development catalogue into `.next/static` — the **client**
bundle. Fourteen fake products downloaded by every visitor. Never rendered, but shipped.

It only happened with the flag **unset**, which is the documented safe default and what a fresh clone
has, so it was the common case. With the flag `false` the guarded `import()` is statically dead and
gets dropped, which is exactly why the first check looked clean. With it unset the comparison can't
be folded, the branch stays reachable, and the catalogue travels with it.

The cause was structural: four `"use client"` components — the card, the store grid, the featured
grid and the detail page — imported from `lib/shopify`, so the whole Storefront fetch layer was
already in the client graph.

Fixed by splitting along the seam the brief asked for, *keep data fetching separate from
presentation*:

- **`src/lib/product.ts`** — the `ShopifyProduct` shape and pure helpers (`isSoldOut`, `toCartItem`,
  `defaultVariant`, `getRelatedProducts`, `displayTags`, `getShowcaseProducts`). Safe anywhere.
- **`src/lib/shopify.ts`** — Storefront queries, `toProduct`, the fetchers, the switch. Server only.

Client components now import `lib/product` and cannot reach the queries or the catalogue behind them.
This also removed a `shopify → placeholder-products → shopify` import cycle that would have left
`FEATURED_TAG` in its TDZ when the catalogue's array literal evaluated.

**No parallel product type was introduced.** `ShopifyProduct` was already the shared model and still
is; the development catalogue simply satisfies it.

## Featured selection

`ShopifyProduct.featured` doesn't exist, and adding a field or a second interface was out of scope, so
selection is a pure selector over data that already exists. Products carrying the plain Shopify tag
`featured` come first — merchandiser-controlled from admin with no deploy, one mechanism for both
sources — then a deterministic top-up in catalogue order, which for Shopify is `sortKey: BEST_SELLING`.
Never random.

`toProduct` now keeps the raw tag list whole; it previously sliced to three, which could drop the
marker before `isFeatured` ever saw it. The three-tag cap moved to `displayTags`, which is a card
concern, and which also stops `featured` rendering as a visible chip.

## The catalogue is deliberately awkward

Not visual filler — it exists to exercise the real components. 14 products across Supplements /
Protein / Beauty / Wellness / Recovery, including single and multi variants, discounts and full
prices, a fully sold-out product, missing ratings, missing badges, cents (`R 219,99`), and names long
enough to test card wrapping.

One product — **Radiance Marine Collagen** — has its cheapest variant sold out while a pricier one is
discounted. That's the exact case #62's per-variant `compareAtPrice` fix targets, and the real store
still has no product that reproduces it. It now renders `R 749` with an `R 899` strikethrough, so
that fix finally has a live test.

## Verification

All three modes were built and served (`next start`, not `next dev`).

**`=true`** — 13/13 automated checks: 14 products on `/store`, all 14 detail pages 200, homepage on
the same catalogue, `R 219,99` cents and whole-rand formatting, sale strikethrough, sold-out pill, no
`Coming Soon` leak, no `featured` chip, unknown slug still 404s. Zero Shopify fetches during the
build.

**`=false`** — zero product links, no development names, development slug 404s, and **0 files**
containing catalogue data in either `.next/static` or the executable server JS.

**unset** — identical to `false` behaviourally, **0 files** in the client bundle. The module remains
in the *server* graph, unreachable behind a false condition; setting the flag explicitly to `false`
removes it there too, which is what `.env.example` recommends for production.

`npx tsc --noEmit` clean, `npm run images:check` passes (48 components). `npm run lint` is **not** a
gate — pre-existing breakage on `main` (#52, `next lint` removed in Next 16), not a regression here.

One process note: an early run showed `/store/radiance-marine-collagen` 404ing. It was a stale
artifact, not a defect — a live `next start` holds `.next` open on Windows, so `rm -rf .next` silently
partially failed and left a 404 page from the previous unset-mode build. The giveaway was that its
`.meta` carried the `products` cache tag, which only the Shopify path sets. It does not reproduce on a
clean build.

## Not in this PR

The store redesign itself (next PR). Shopify-backed bundles (#65), pagination past 50 (#64), the
wishlist/cart id mismatch (#63), category routes. No changes to Shopify auth, webhook logic or
`/api/revalidate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQKmN3D5Z9BhEbyoCfJSF2
