### PR TITLE
fix: harden the authentication workflow

### DIFF
--- a/docs/auth-account-management.md
+++ b/docs/auth-account-management.md
@@ -1,0 +1,182 @@
+# Account & provider management — design notes
+
+**Status: not implemented. This is the plan, not a description of the code.**
+
+Written during the Phase 10 auth review. Nothing in `/account` manages sign-in methods today;
+this records how it should be built when someone picks it up, and what the auth layer already
+does and doesn't give you.
+
+---
+
+## Where things actually stand
+
+`/account` is a dashboard of **stub cards** (`{/* Stub cards */}` in `AccountContent.tsx`) —
+My Orders, Wishlist, Profile Settings, Loyalty Points. They have `cursor-pointer` and a hover
+lift, but no click handler and no route behind them. There is no settings page, no profile
+editing, and no notion of connected providers anywhere in the app.
+
+So there is no "Account Settings architecture" to extend. The question this phase actually
+answers is narrower: **does the auth layer obstruct building one?** It does not. What follows
+is what to build and the traps to avoid.
+
+### What already exists in your favour
+
+| Thing | Where | Why it matters here |
+| --- | --- | --- |
+| Single Firebase boundary | `src/context/AuthContext.tsx` | Every Firebase call already lives in one file. Linking methods slot in beside `signIn`/`signUp` with no restructuring. |
+| Central error mapping | `src/lib/auth-errors.ts` | Duck-typed, no `instanceof`, no SDK import. The four linking codes are already mapped (no callers yet). |
+| `auth/requires-recent-login` mapped | `src/lib/auth-errors.ts` | The prerequisite for every sensitive operation below, already worded for users. |
+| Popup → redirect fallback | `socialSignIn` in `AuthContext` | `linkWithPopup`/`linkWithRedirect` need exactly the same shape. Copy the pattern, don't reinvent it. |
+| Pending credential preserved | `socialSignIn` catch block | On `auth/account-exists-with-different-credential` the error propagates intact, so the credential is still recoverable. There is a comment marking the spot. |
+| Shared provider instances | `src/lib/firebase.ts` | `googleProvider` / `appleProvider` are exported singletons with scopes configured. Reuse them for linking and reauth. |
+
+Nothing needs undoing first.
+
+---
+
+## Firebase APIs required
+
+All from `firebase/auth`.
+
+**Reading state**
+
+- `user.providerData` — array of `UserInfo`. The `providerId` values you'll see are
+  `"google.com"`, `"apple.com"`, `"password"`. This is the source of truth for "what is
+  connected"; derive it, don't mirror it into state.
+
+**Linking**
+
+- `linkWithPopup(user, provider)` → `UserCredential`
+- `linkWithRedirect(user, provider)` — the fallback when the popup is blocked
+- `linkWithCredential(user, credential)` — for a credential recovered from a conflict
+- `GoogleAuthProvider.credentialFromError(err)` / `OAuthProvider.credentialFromError(err)` —
+  recovers the pending credential from `auth/account-exists-with-different-credential`
+
+**Unlinking**
+
+- `unlink(user, providerId)` → `User`
+
+**Reauthentication**
+
+- `reauthenticateWithPopup(user, provider)` — social
+- `reauthenticateWithCredential(user, credential)` — password, built with
+  `EmailAuthProvider.credential(email, password)`
+
+**Adjacent operations that will land in the same settings screen**
+
+- `updatePassword(user, next)`
+- `verifyBeforeUpdateEmail(user, next)` — prefer this over `updateEmail`; it verifies the new
+  address before switching, rather than after
+- `deleteUser(user)`
+
+**Deliberately not used**
+
+- `fetchSignInMethodsForEmail` — the account-enumeration surface Phase 7 closed. It also
+  returns nothing useful once Firebase's email-enumeration protection is on. Never reintroduce
+  it to answer "which providers does this email have?" for a *not-yet-signed-in* user.
+
+---
+
+## Recent login
+
+Firebase invalidates sensitive operations when the sign-in is not recent (roughly five
+minutes). Treat `auth/requires-recent-login` as **expected control flow, not an error** for:
+
+- `deleteUser`
+- `updatePassword`
+- `verifyBeforeUpdateEmail`
+- `unlink` and `linkWithCredential` (these *can* throw it; don't assume they won't)
+
+### Recommended shape: reauthenticate on demand
+
+Do not gate the settings screen behind a pre-emptive password prompt. Attempt the operation,
+catch the code, prompt, retry:
+
+```
+attempt operation
+  └─ auth/requires-recent-login
+       ├─ user has "password" in providerData → inline password prompt
+       │                                        → reauthenticateWithCredential
+       └─ social-only account                 → reauthenticateWithPopup(existing provider)
+                                                (popup blocked → reauthenticateWithRedirect)
+  └─ retry the original operation once
+```
+
+Most users never see the prompt, and nobody is asked for a password before they've decided to
+do anything.
+
+**Redirect-based reauth loses in-progress form state.** If the settings screen has unsaved
+input, persist it before calling the redirect variant — the same problem `saveDestination`
+solves for sign-in, and worth reusing that pattern rather than inventing another.
+
+---
+
+## The safety rule that matters most
+
+> A user must never be able to remove their last remaining way in.
+
+Firebase **does not enforce this.** `unlink` will happily strip the final provider and leave an
+account nobody can authenticate against. Recovery then needs Admin SDK intervention.
+
+Enforce it client-side, in a pure function so it can be tested without a browser:
+
+```ts
+// src/lib/providers.ts
+export function canUnlink(providerIds: string[], target: string): boolean {
+  return providerIds.includes(target) && providerIds.length > 1;
+}
+```
+
+Then disable the control *and* explain why, rather than failing on click. The UI should say
+something like "Add another sign-in method before removing this one."
+
+One subtlety: a `"password"` provider is only a real way back in if the user knows the
+password. Someone who signed up with Google and later got a password credential via the reset
+flow (see Phase 7 — a reset on a federated account *creates* a password credential) may not
+realise they have one. Count it as a method, but don't treat it as a reason to be relaxed about
+the last-provider rule.
+
+---
+
+## Edge cases
+
+| Case | What happens | What to do |
+| --- | --- | --- |
+| Unlinking the last provider | Account becomes unreachable; Firebase allows it | Block in UI via `canUnlink`; never rely on the SDK |
+| `auth/credential-already-in-use` | The Google/Apple account is already on a *different* Hey Beautiful account | Explain plainly. **Firebase has no built-in account merge** — merging means a server-side migration of orders/wishlist and re-keying, which is a project of its own. Do not attempt it client-side. |
+| `auth/provider-already-linked` | Already connected | Shouldn't be reachable if the UI derives from `providerData`; handle anyway |
+| Apple re-linking | Apple releases the user's name **only on first authorization**. Unlink → relink returns no name. | Never overwrite a stored `displayName` with an empty value on relink. `captureProviderDisplayName` in `AuthContext` already guards the capture side. |
+| Social-only account, "change password" | There is no password to change | Offer "set a password" (send a reset link) instead of a change-password form. Decide from `providerData`, not by attempting and failing. |
+| Linking a verified Google account to an unverified password account | `emailVerified` may or may not flip | Re-read `user.emailVerified` after linking rather than assuming; `reloadUser()` already exists for this |
+| Provider email ≠ account email | Linking Google with a different address doesn't change the primary email | Show which address each connected method carries, so the list isn't confusing |
+| Popup blocked during link or reauth | Same failure as sign-in | Reuse `isPopupFallbackError` from `src/lib/auth-errors.ts` |
+| Unlinking mid-session | `providerData` changes but the session stays valid | Re-derive from `user.providerData`; don't cache a snapshot |
+
+---
+
+## Recommended implementation order
+
+1. **`src/lib/providers.ts`** — pure helpers: `canUnlink`, a `providerId → label` map, and a
+   `describeProviders(user)` derivation. Testable with no browser.
+2. **`AuthContext`** — add `linkProvider`, `unlinkProvider`, `reauthenticate`. Keep the
+   popup→redirect fallback identical to `socialSignIn`. Expose `providers` as a *derived*
+   value from `user.providerData`, not new state.
+3. **`/account/settings`** — a real route following the project's server-page +
+   `*Content.tsx` client-component pattern. Add it to `PROTECTED` in `src/proxy.ts`.
+4. **Reauthentication prompt** — the on-demand flow above.
+5. **Conflict-driven linking** — only then wire the `auth/account-exists-with-different-credential`
+   path at sign-in to offer "connect these accounts", using the preserved pending credential.
+
+Steps 1–3 are low risk. Step 5 is the one with real teeth and should not be attempted until
+1–4 are solid.
+
+---
+
+## Why none of this was built now
+
+Every item needs a settings screen that doesn't exist, and step 5 needs a reauthentication
+story that doesn't exist either. Building linking against stub cards would mean shipping a
+security-sensitive flow with no home, no tests, and no way to verify it — the auth work so far
+has been verifiable at every step, and this would have been the first part that wasn't.
+
+The auth layer is ready for it. Nothing above requires changing code that already ships.

--- a/src/app/(auth)/(card)/login/LoginContent.tsx
+++ b/src/app/(auth)/(card)/login/LoginContent.tsx
@@ -111,6 +111,11 @@ function LoginForm() {
     e.preventDefault();
     if (loading) return;
     setError("");
+    // A conflict raised by a social attempt is about a different sign-in method — leaving
+    // it up would pin that panel over an unrelated email/password failure. Both sources
+    // have to go, since credentialConflict falls back to the redirect-path one.
+    setPopupConflict(null);
+    if (redirectError) clearRedirectError();
     setLoading(true);
     try {
       await signIn(email, password, remember);

--- a/src/app/(auth)/(card)/login/LoginContent.tsx
+++ b/src/app/(auth)/(card)/login/LoginContent.tsx
@@ -1,34 +1,60 @@
 "use client";
 
-import { Suspense, useEffect, useMemo, useState } from "react";
+import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useAuth } from "@/context/AuthContext";
 import SignInPane from "@/components/auth/SignInPane";
 import { useAuthTransition } from "@/components/auth/AuthTransitionContext";
-import AuthErrorToast, { getAuthErrorMessage } from "@/components/auth/AuthErrorToast";
-import { REDIRECT_KEY } from "@/lib/constants";
-import { resolveDestination } from "@/lib/redirect";
+import AuthErrorToast from "@/components/auth/AuthErrorToast";
+import {
+  getAuthErrorMessage,
+  getConflictEmail,
+  isCredentialConflictError,
+} from "@/lib/auth-errors";
+import {
+  DEFAULT_DESTINATION,
+  SESSION_EXPIRED_PARAM,
+  clearDestination,
+  postAuthDestination,
+  readDestination,
+  resolveDestination,
+  saveDestination,
+} from "@/lib/redirect";
 
 function LoginForm() {
   const router = useRouter();
   const params = useSearchParams();
   const { setLastLoginFrom } = useAuthTransition();
   const fromParam = params.get("from");
-  const destination = useMemo(() => {
-    if (fromParam) return resolveDestination(fromParam);
-    const saved =
-      typeof window !== "undefined"
-        ? sessionStorage.getItem(REDIRECT_KEY)
-        : null;
-    return saved ?? "/account";
-  }, [fromParam]);
-  const { signIn, signInWithGoogle, signInWithApple, user, loading: authLoading } = useAuth();
+  // A protected page found the session gone and sent them here. Say so, rather than leaving
+  // them to wonder why they're suddenly looking at a sign-in form.
+  const sessionExpired = params.get(SESSION_EXPIRED_PARAM) === "expired";
+  // Precedence (documented in src/lib/redirect.ts): a `from` on the URL always decides,
+  // *including* when it is invalid — falling through to the stored value would let a
+  // hostile `?from=` interact with stale client state. Storage is consulted only when no
+  // `from` was supplied at all, which is the social-redirect return.
+  const destination = useMemo(
+    () =>
+      fromParam !== null
+        ? resolveDestination(fromParam)
+        : readDestination() ?? DEFAULT_DESTINATION,
+    [fromParam]
+  );
+  const {
+    signIn,
+    signInWithGoogle,
+    signInWithApple,
+    user,
+    loading: authLoading,
+    redirectError,
+    clearRedirectError,
+  } = useAuth();
 
-  // Stash it on the card so a /login → /signup → /login bounce keeps the
-  // destination; AuthCard outlives both routes, so the value survives.
+  // Stash the resolved destination on the card so a /login → /signup → /login bounce keeps
+  // it; AuthCard outlives both routes, so the value survives the swap.
   useEffect(() => {
-    if (fromParam) setLastLoginFrom(fromParam);
-  }, [fromParam, setLastLoginFrom]);
+    if (destination !== DEFAULT_DESTINATION) setLastLoginFrom(destination);
+  }, [destination, setLastLoginFrom]);
 
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -36,17 +62,50 @@ function LoginForm() {
   const [remember, setRemember] = useState(true);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
+  // Conflicting address, or "" when Firebase didn't name one. null = no conflict.
+  const [popupConflict, setPopupConflict] = useState<string | null>(null);
 
+  // Turns a popup-path failure into UI. The redirect path is derived below instead.
+  const reportAuthError = useCallback((err: unknown) => {
+    if (isCredentialConflictError(err)) {
+      setPopupConflict(getConflictEmail(err) ?? "");
+      return;
+    }
+    const message = getAuthErrorMessage(err);
+    if (message) setError(message);
+  }, []);
+
+  // A redirect sign-in fails *before* this page reloads, so its error arrives through
+  // context rather than a catch. Derive the display from it rather than copying it into
+  // local state — the context already holds it, and mirroring would only add a render pass.
+  const redirectConflict = isCredentialConflictError(redirectError)
+    ? (getConflictEmail(redirectError) ?? "")
+    : null;
+  const credentialConflict = popupConflict ?? redirectConflict;
+  const errorMessage =
+    error ||
+    (redirectError && !isCredentialConflictError(redirectError)
+      ? getAuthErrorMessage(redirectError)
+      : "");
+
+  const dismissError = () => {
+    setError("");
+    if (redirectError) clearRedirectError();
+  };
+
+  // The single navigation path. Email sign-in, popup sign-in and the post-redirect return
+  // all land here once Firebase reports a user, so the destination is resolved once and the
+  // stored value consumed exactly once. Ref-guarded because Strict Mode double-invokes.
+  //
+  // postAuthDestination is what routes an unverified user heading for /checkout through
+  // /verify-email first, instead of letting checkout bounce them there.
+  const navigated = useRef(false);
   useEffect(() => {
-    if (authLoading || !user) return;
-    const dest =
-      (typeof window !== "undefined"
-        ? sessionStorage.getItem(REDIRECT_KEY)
-        : null) ?? destination;
-    sessionStorage.removeItem(REDIRECT_KEY);
-    router.push(dest);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [user, authLoading]);
+    if (authLoading || !user || navigated.current) return;
+    navigated.current = true;
+    clearDestination();
+    router.push(postAuthDestination(destination, user.emailVerified));
+  }, [user, authLoading, destination, router]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -55,7 +114,8 @@ function LoginForm() {
     setLoading(true);
     try {
       await signIn(email, password, remember);
-      router.push(destination);
+      // Navigation is the effect above's job — pushing here too raced it and could send
+      // the user somewhere different from the social paths.
     } catch (err) {
       setError(getAuthErrorMessage(err));
     } finally {
@@ -64,16 +124,20 @@ function LoginForm() {
   };
 
   const handleSocial = async (fn: () => Promise<void>) => {
-    sessionStorage.setItem(REDIRECT_KEY, destination);
+    // Only the social paths write storage: signInWithRedirect is a full-page navigation
+    // that destroys this component's state, so the destination needs somewhere to live.
+    saveDestination(destination);
     setError("");
+    setPopupConflict(null);
+    // A stale failure from a previous redirect shouldn't linger over a fresh attempt.
+    if (redirectError) clearRedirectError();
     try {
       await fn();
-      // useEffect([user, authLoading]) handles navigation and cleanup for both
-      // popup-success and post-redirect-return paths
+      // The effect above handles navigation and cleanup for both popup-success and
+      // post-redirect-return paths.
     } catch (err) {
-      sessionStorage.removeItem(REDIRECT_KEY);
-      const msg = getAuthErrorMessage(err);
-      if (msg) setError(msg);
+      clearDestination();
+      reportAuthError(err);
     }
   };
 
@@ -89,12 +153,14 @@ function LoginForm() {
         remember={remember}
         onRememberChange={setRemember}
         loading={loading}
+        credentialConflict={credentialConflict}
+        sessionExpired={sessionExpired}
         onSubmit={handleSubmit}
         onGoogle={() => handleSocial(signInWithGoogle)}
         onApple={() => handleSocial(signInWithApple)}
       />
 
-      <AuthErrorToast message={error} onDismiss={() => setError("")} />
+      <AuthErrorToast message={errorMessage} onDismiss={dismissError} />
     </>
   );
 }

--- a/src/app/(auth)/(card)/signup/SignupContent.tsx
+++ b/src/app/(auth)/(card)/signup/SignupContent.tsx
@@ -1,25 +1,59 @@
 "use client";
 
-import { useEffect, useState, useMemo } from "react";
-import { useRouter } from "next/navigation";
+import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useAuth } from "@/context/AuthContext";
 import SignUpPane from "@/components/auth/SignUpPane";
-import AuthErrorToast, { getAuthErrorMessage } from "@/components/auth/AuthErrorToast";
-import { REDIRECT_KEY } from "@/lib/constants";
+import { useAuthTransition } from "@/components/auth/AuthTransitionContext";
+import AuthErrorToast from "@/components/auth/AuthErrorToast";
+import {
+  getAuthErrorMessage,
+  getConflictEmail,
+  isCredentialConflictError,
+  isEmailInUseError,
+} from "@/lib/auth-errors";
+import { isPlausibleEmail } from "@/lib/email";
+import { MIN_PASSWORD_LENGTH } from "@/lib/constants";
+import { getPasswordStrength } from "@/lib/password";
+import {
+  DEFAULT_DESTINATION,
+  clearDestination,
+  postAuthDestination,
+  readDestination,
+  resolveDestination,
+  saveDestination,
+  withFrom,
+} from "@/lib/redirect";
 
-function getStrength(pw: string): number {
-  if (!pw) return 0;
-  let score = 0;
-  if (pw.length >= 8) score++;
-  if (/[A-Z]/.test(pw)) score++;
-  if (/[0-9]/.test(pw)) score++;
-  if (/[^A-Za-z0-9]/.test(pw)) score++;
-  return score;
-}
-
-export default function SignupContent() {
+function SignupForm() {
   const router = useRouter();
-  const { signUp, signInWithGoogle, signInWithApple, user, loading: authLoading } = useAuth();
+  const params = useSearchParams();
+  const { setLastLoginFrom } = useAuthTransition();
+  const fromParam = params.get("from");
+  // Same precedence as /login (see src/lib/redirect.ts): an invalid `from` resolves to the
+  // default rather than falling through to stored state.
+  const destination = useMemo(
+    () =>
+      fromParam !== null
+        ? resolveDestination(fromParam)
+        : readDestination() ?? DEFAULT_DESTINATION,
+    [fromParam]
+  );
+  const {
+    signUp,
+    signInWithGoogle,
+    signInWithApple,
+    user,
+    loading: authLoading,
+    redirectError,
+    clearRedirectError,
+  } = useAuth();
+
+  // Keeps SignUpPane's "Sign in" link pointing back at the destination even when the user
+  // landed on /signup?from=… directly rather than bouncing through /login.
+  useEffect(() => {
+    if (destination !== DEFAULT_DESTINATION) setLastLoginFrom(destination);
+  }, [destination, setLastLoginFrom]);
 
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
@@ -29,26 +63,81 @@ export default function SignupContent() {
   const [agreed, setAgreed] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
-  const [fieldErrors, setFieldErrors] = useState<{ password?: string; confirm?: string; agree?: string }>({});
+  const [fieldErrors, setFieldErrors] = useState<{
+    email?: string;
+    password?: string;
+    confirm?: string;
+    agree?: string;
+  }>({});
+  // Not an error state so much as "you already have an account" — rendered inline with
+  // routes to sign in or reset, rather than as a toast that vanishes.
+  const [emailAlreadyInUse, setEmailAlreadyInUse] = useState(false);
+  // Conflicting address, or "" when Firebase didn't name one. null = no conflict.
+  const [popupConflict, setPopupConflict] = useState<string | null>(null);
 
-  const strength = useMemo(() => getStrength(password), [password]);
+  // Turns a popup-path or email-signup failure into UI. The redirect path is derived below.
+  const reportAuthError = useCallback((err: unknown) => {
+    if (isCredentialConflictError(err)) {
+      setPopupConflict(getConflictEmail(err) ?? "");
+      return;
+    }
+    if (isEmailInUseError(err)) {
+      setEmailAlreadyInUse(true);
+      return;
+    }
+    const message = getAuthErrorMessage(err);
+    if (message) setError(message);
+  }, []);
 
-  // Navigate after popup-success or after signInWithRedirect round-trip returns.
+  // A redirect sign-in fails *before* this page reloads, so its error arrives through
+  // context rather than a catch. Derive the display from it rather than copying it into
+  // local state — the context already holds it, and mirroring would only add a render pass.
+  const redirectConflict = isCredentialConflictError(redirectError)
+    ? (getConflictEmail(redirectError) ?? "")
+    : null;
+  const credentialConflict = popupConflict ?? redirectConflict;
+  const errorMessage =
+    error ||
+    (redirectError && !isCredentialConflictError(redirectError)
+      ? getAuthErrorMessage(redirectError)
+      : "");
+
+  const dismissError = () => {
+    setError("");
+    if (redirectError) clearRedirectError();
+  };
+
+  const strength = useMemo(() => getPasswordStrength(password), [password]);
+
+  // Claimed by whichever path navigates first, so the auth-state effect and the submit
+  // handler can never both push.
+  const navigated = useRef(false);
+
+  // Social sign-up: navigate after popup-success or after the signInWithRedirect round trip
+  // returns. Email sign-up claims the navigation itself (see handleSubmit).
+  //
+  // Google and Apple normally hand back an already-verified email, but that isn't
+  // guaranteed, so the same unverified routing as /login applies rather than assuming it.
   useEffect(() => {
-    if (authLoading || !user) return;
-    sessionStorage.removeItem(REDIRECT_KEY);
-    router.push("/account");
-  }, [user, authLoading, router]);
+    if (authLoading || !user || navigated.current) return;
+    navigated.current = true;
+    clearDestination();
+    router.push(postAuthDestination(destination, user.emailVerified));
+  }, [user, authLoading, destination, router]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (loading) return;
     setError("");
+    setEmailAlreadyInUse(false);
 
+    // Everything checkable locally is checked here, so an obviously-invalid form never
+    // costs a network round trip and the user gets a precise inline error instead of a
+    // translated Firebase code.
     const errs: typeof fieldErrors = {};
-    // Firebase requires a 6+ char password — pre-validate for a deterministic
-    // inline error instead of a round-trip that returns auth/weak-password.
-    if (password.length < 6) errs.password = "Password must be at least 6 characters.";
+    if (!isPlausibleEmail(email)) errs.email = "Please enter a valid email address.";
+    if (password.length < MIN_PASSWORD_LENGTH)
+      errs.password = `Password must be at least ${MIN_PASSWORD_LENGTH} characters.`;
     if (confirm !== password) errs.confirm = "Passwords do not match.";
     if (!agreed) errs.agree = "Please accept the terms to continue.";
     if (Object.keys(errs).length) {
@@ -57,28 +146,47 @@ export default function SignupContent() {
     }
     setFieldErrors({});
 
+    // Claim the navigation *before* creating the account. signUp() awaits the profile
+    // update and verification email after the user already exists, so the effect above
+    // would otherwise fire first and send a brand-new signup straight to `destination`
+    // instead of through /verify-email.
+    navigated.current = true;
     setLoading(true);
     try {
-      await signUp(email, password, name);
-      router.push("/verify-email");
+      // Only rejects when the account was NOT created. A partial failure after creation
+      // comes back in the result, because the account is real and the user must be sent on
+      // to verification rather than told to try again.
+      const result = await signUp(email, password, name);
+      clearDestination();
+      const verifyUrl = withFrom("/verify-email", destination);
+      const separator = verifyUrl.includes("?") ? "&" : "?";
+      router.push(
+        result.verificationEmailSent ? verifyUrl : `${verifyUrl}${separator}sent=0`
+      );
     } catch (err) {
-      setError(getAuthErrorMessage(err));
+      navigated.current = false;
+      // email-already-in-use isn't a failure to explain away — they have an account, and
+      // reportAuthError turns it into the inline route back in.
+      reportAuthError(err);
     } finally {
       setLoading(false);
     }
   };
 
   const handleSocial = async (fn: () => Promise<void>) => {
-    sessionStorage.setItem(REDIRECT_KEY, "/account");
+    // Only the social paths write storage — signInWithRedirect destroys this component.
+    saveDestination(destination);
     setError("");
+    setPopupConflict(null);
+    // A stale failure from a previous redirect shouldn't linger over a fresh attempt.
+    if (redirectError) clearRedirectError();
     try {
       await fn();
-      // useEffect([user, authLoading]) handles navigation and cleanup for both
-      // popup-success and post-redirect-return paths
+      // The effect above handles navigation and cleanup for both popup-success and
+      // post-redirect-return paths.
     } catch (err) {
-      sessionStorage.removeItem(REDIRECT_KEY);
-      const msg = getAuthErrorMessage(err);
-      if (msg) setError(msg);
+      clearDestination();
+      reportAuthError(err);
     }
   };
 
@@ -88,7 +196,14 @@ export default function SignupContent() {
         name={name}
         onNameChange={setName}
         email={email}
-        onEmailChange={setEmail}
+        onEmailChange={(value) => {
+          setEmail(value);
+          // Editing the address makes the "already registered" notice stale.
+          if (emailAlreadyInUse) setEmailAlreadyInUse(false);
+          if (fieldErrors.email) setFieldErrors((f) => ({ ...f, email: undefined }));
+        }}
+        emailAlreadyInUse={emailAlreadyInUse}
+        credentialConflict={credentialConflict}
         password={password}
         onPasswordChange={setPassword}
         confirm={confirm}
@@ -108,7 +223,16 @@ export default function SignupContent() {
         onApple={() => handleSocial(signInWithApple)}
       />
 
-      <AuthErrorToast message={error} onDismiss={() => setError("")} />
+      <AuthErrorToast message={errorMessage} onDismiss={dismissError} />
     </>
+  );
+}
+
+export default function SignupContent() {
+  // useSearchParams requires a Suspense boundary (matches LoginContent).
+  return (
+    <Suspense fallback={null}>
+      <SignupForm />
+    </Suspense>
   );
 }

--- a/src/app/(auth)/(card)/signup/SignupContent.tsx
+++ b/src/app/(auth)/(card)/signup/SignupContent.tsx
@@ -178,6 +178,8 @@ function SignupForm() {
     saveDestination(destination);
     setError("");
     setPopupConflict(null);
+    // The email path's notice doesn't apply to the provider they just picked.
+    setEmailAlreadyInUse(false);
     // A stale failure from a previous redirect shouldn't linger over a fresh attempt.
     if (redirectError) clearRedirectError();
     try {
@@ -205,9 +207,22 @@ function SignupForm() {
         emailAlreadyInUse={emailAlreadyInUse}
         credentialConflict={credentialConflict}
         password={password}
-        onPasswordChange={setPassword}
+        onPasswordChange={(value) => {
+          setPassword(value);
+          // Clear both: the strength hint in SignUpPane is gated on !fieldErrors.password,
+          // so leaving it set hides the "use at least 8 characters" guidance for good, and
+          // a length fix usually resolves the mismatch error too.
+          if (fieldErrors.password)
+            setFieldErrors((f) => ({ ...f, password: undefined }));
+          if (fieldErrors.confirm)
+            setFieldErrors((f) => ({ ...f, confirm: undefined }));
+        }}
         confirm={confirm}
-        onConfirmChange={setConfirm}
+        onConfirmChange={(value) => {
+          setConfirm(value);
+          if (fieldErrors.confirm)
+            setFieldErrors((f) => ({ ...f, confirm: undefined }));
+        }}
         showPassword={showPassword}
         onTogglePassword={() => setShowPassword((v) => !v)}
         agreed={agreed}

--- a/src/app/(auth)/forgot-password/ForgotPasswordContent.tsx
+++ b/src/app/(auth)/forgot-password/ForgotPasswordContent.tsx
@@ -1,35 +1,73 @@
 "use client";
 
-import { useState } from "react";
+import { Suspense, useState } from "react";
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
 import { motion, AnimatePresence } from "framer-motion";
 import { CheckCircle } from "lucide-react";
 import { fadeUp, scaleIn } from "@/lib/motion";
 import { useAuth } from "@/context/AuthContext";
 import AuthForm from "@/components/auth/AuthForm";
 import FloatingInput from "@/components/auth/FloatingInput";
-import AuthErrorToast, { getAuthErrorMessage } from "@/components/auth/AuthErrorToast";
+import AuthErrorToast from "@/components/auth/AuthErrorToast";
+import { getAuthErrorMessage } from "@/lib/auth-errors";
+import { DEFAULT_DESTINATION, resolveDestination, withFrom } from "@/lib/redirect";
+import { isPlausibleEmail } from "@/lib/email";
+import { useCooldown } from "@/components/auth/useCooldown";
 
-export default function ForgotPasswordContent() {
+/** Matches the verification resend cooldown, so the two flows behave the same way. */
+const RESEND_COOLDOWN_SECONDS = 60;
+
+function ForgotPassword() {
+  const params = useSearchParams();
+  // This route renders outside the (card) group, so AuthCard — and the lastLoginFrom it
+  // owns — unmounts on the way in. The URL is the only thing that survives the round trip,
+  // which is why the destination has to travel as ?from= rather than in context.
+  const fromParam = params.get("from");
+  const destination =
+    fromParam !== null ? resolveDestination(fromParam) : DEFAULT_DESTINATION;
+  const backToSignIn = withFrom(
+    "/login",
+    destination === DEFAULT_DESTINATION ? null : destination
+  );
+
   const { resetPassword } = useAuth();
   const [email, setEmail] = useState("");
   const [loading, setLoading] = useState(false);
   const [sent, setSent] = useState(false);
   const [error, setError] = useState("");
+  const [emailError, setEmailError] = useState("");
+  const cooldown = useCooldown();
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (loading) return;
+  const requestReset = async () => {
     setError("");
     setLoading(true);
     try {
+      // Resolves even when no account exists — see resetPassword in AuthContext. So the
+      // success path here says nothing about whether the address is registered.
       await resetPassword(email);
       setSent(true);
+      cooldown.start(RESEND_COOLDOWN_SECONDS);
     } catch (err) {
+      // Only operational failures reach here (network, rate limiting). None of them depend
+      // on whether the account exists, so showing them leaks nothing.
       setError(getAuthErrorMessage(err));
     } finally {
       setLoading(false);
     }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (loading) return;
+    // Catch a malformed address before spending a request on it — and before Firebase can
+    // answer with anything at all.
+    if (!isPlausibleEmail(email)) {
+      setEmailError("Please enter a valid email address.");
+      return;
+    }
+    setEmailError("");
+    await requestReset();
   };
 
   return (
@@ -60,16 +98,45 @@ export default function ForgotPasswordContent() {
               >
                 Check your inbox
               </h3>
+              {/* Deliberately conditional wording: "if an account exists". Confirming that
+                  a link *was* sent would tell anyone who typed an address whether that
+                  person has an account here. */}
               <p
-                className="text-ink/55 leading-relaxed mb-7 max-w-xs"
+                className="text-ink/55 leading-relaxed mb-4 max-w-xs"
                 style={{ fontFamily: "var(--font-manrope)", fontSize: "0.85rem" }}
               >
-                A password reset link has been sent to{" "}
-                <span className="text-ink font-medium">{email}</span>.
+                If an account exists for{" "}
+                <span className="text-ink font-medium">{email}</span>, you&apos;ll receive
+                instructions for resetting your password shortly.
               </p>
-              <Link href="/login" className="btn-outline">
-                Back to Sign In
-              </Link>
+              {/* Covers the provider-only case without looking anything up: we can't ask
+                  which sign-in methods an account has without creating the same oracle. */}
+              <p
+                className="text-ink/45 leading-relaxed mb-6 max-w-xs"
+                style={{ fontFamily: "var(--font-manrope)", fontSize: "0.78rem" }}
+              >
+                If you normally sign in with Google or Apple, use that button on the sign-in
+                page instead — you may not have a password to reset.
+              </p>
+
+              <div className="w-full flex flex-col gap-2.5 max-w-xs">
+                <Link href={backToSignIn} className="btn-outline w-full">
+                  Back to Sign In
+                </Link>
+                <button
+                  type="button"
+                  onClick={requestReset}
+                  disabled={loading || cooldown.active}
+                  className="text-ink/45 hover:text-dusty-pink transition-colors disabled:opacity-60 disabled:hover:text-ink/45 py-1"
+                  style={{ fontFamily: "var(--font-manrope)", fontSize: "0.78rem" }}
+                >
+                  {loading
+                    ? "Sending…"
+                    : cooldown.active
+                      ? `Didn't get it? Resend in ${cooldown.remaining}s`
+                      : "Didn't get it? Send again"}
+                </button>
+              </div>
             </motion.div>
           ) : (
             <motion.form
@@ -82,7 +149,11 @@ export default function ForgotPasswordContent() {
                 label="Email Address"
                 type="email"
                 value={email}
-                onChange={(e) => setEmail(e.target.value)}
+                onChange={(e) => {
+                  setEmail(e.target.value);
+                  if (emailError) setEmailError("");
+                }}
+                error={emailError}
                 autoComplete="email"
                 required
               />
@@ -100,7 +171,7 @@ export default function ForgotPasswordContent() {
 
               <motion.div variants={fadeUp} className="text-center">
                 <Link
-                  href="/login"
+                  href={backToSignIn}
                   className="text-ink/50 hover:text-dusty-pink transition-colors"
                   style={{ fontFamily: "var(--font-manrope)", fontSize: "0.82rem" }}
                 >
@@ -114,5 +185,14 @@ export default function ForgotPasswordContent() {
 
       <AuthErrorToast message={error} onDismiss={() => setError("")} />
     </>
+  );
+}
+
+export default function ForgotPasswordContent() {
+  // useSearchParams requires a Suspense boundary (matches LoginContent).
+  return (
+    <Suspense fallback={null}>
+      <ForgotPassword />
+    </Suspense>
   );
 }

--- a/src/app/(auth)/verify-email/VerifyEmailContent.tsx
+++ b/src/app/(auth)/verify-email/VerifyEmailContent.tsx
@@ -6,13 +6,31 @@ import { motion, AnimatePresence } from "framer-motion";
 import { Mail, CheckCircle } from "lucide-react";
 import { fadeUp } from "@/lib/motion";
 import { useAuth } from "@/context/AuthContext";
-import { resolveDestination } from "@/lib/redirect";
+import { useCart } from "@/context/CartContext";
+import { useWishlist } from "@/context/WishlistContext";
+import { requiresVerification, resolveDestination, withFrom } from "@/lib/redirect";
 import AuthForm from "@/components/auth/AuthForm";
-import AuthErrorToast, { getAuthErrorMessage } from "@/components/auth/AuthErrorToast";
+import AuthErrorToast from "@/components/auth/AuthErrorToast";
+import { getAuthErrorMessage, isRateLimitError } from "@/lib/auth-errors";
+import { useCooldown } from "@/components/auth/useCooldown";
 
-// How often to re-check emailVerified while the page is open. Firebase has no
-// live listener for verification, so we poll (and also re-check on tab focus).
+// How often to re-check emailVerified while the page is open and visible. Firebase has no
+// live listener for verification, so we poll (and also re-check when the tab regains focus).
 const VERIFY_POLL_INTERVAL_MS = 3000;
+
+/**
+ * How long to keep polling automatically. Someone who opens this page and wanders off
+ * shouldn't leave a tab firing a request every 3s all afternoon — that's thousands of
+ * pointless calls and a good way to get rate-limited. After this we stop and hand control
+ * back to the user, who can check on demand; returning to the tab still triggers a check.
+ */
+const VERIFY_POLL_MAX_MS = 15 * 60 * 1000;
+
+/** Firebase throttles verification sends, so match it rather than discovering it. */
+const RESEND_COOLDOWN_SECONDS = 60;
+
+/** How long the "sent" confirmation stays up before the cooldown counter takes over. */
+const RESENT_NOTICE_MS = 4000;
 
 function VerifyEmail() {
   const router = useRouter();
@@ -20,18 +38,32 @@ function VerifyEmail() {
   // Where to send the user once verified — the checkout guard passes ?from=/checkout…;
   // resolveDestination falls back to /account and blocks open redirects.
   const dest = resolveDestination(params.get("from"));
-  // /checkout is *enforced* (unlike advisory /account), so a manual "continue"
-  // there would just bounce off the checkout guard back to this page while
-  // unverified — and the verified case is already handled by the auto-redirect
-  // below. So the manual CTA only makes sense for the advisory destination.
-  const showManualContinue = !dest.startsWith("/checkout");
+  // A destination that requires verification would just bounce off its own guard back to
+  // this page while unverified — and the verified case is already handled by the
+  // auto-redirect below. So the manual CTA only makes sense for advisory destinations.
+  const showManualContinue = !requiresVerification(dest);
+  // Sign-up sets `sent=0` when the account was created but the verification email couldn't
+  // be sent. The account is real and the session is live — only the email is missing — so
+  // say so plainly instead of claiming we sent something we didn't.
+  const initialSendFailed = params.get("sent") === "0";
   const { user, loading, sendVerification, reloadUser, signOut } = useAuth();
+  const { clearCart } = useCart();
+  const { clearWishlist } = useWishlist();
   const [resending, setResending] = useState(false);
   const [resent, setResent] = useState(false);
+  const cooldown = useCooldown();
+  const [checking, setChecking] = useState(false);
+  const [checkedNotVerified, setCheckedNotVerified] = useState(false);
+  // Flipped when the automatic poll gives up, swapping it for a user-driven check.
+  const [pollExhausted, setPollExhausted] = useState(false);
   const [error, setError] = useState("");
   // One-shot navigation guard — Strict Mode double-invokes effects, and the
   // mount check / poll / focus handler could otherwise each fire a navigation.
   const redirected = useRef(false);
+  // Read inside the interval so the deadline survives re-renders without re-running the
+  // polling effect (which would restart the window each time).
+  const pollDeadline = useRef(0);
+  const exhausted = useRef(false);
 
   const navOnce = useCallback(
     (path: string) => {
@@ -42,16 +74,20 @@ function VerifyEmail() {
     [router]
   );
 
-  // No session (e.g. opened directly) — nothing to verify, send to login.
+  // No session (e.g. opened directly) — nothing to verify, send to login, carrying the
+  // destination so signing in doesn't lose where they were headed.
   useEffect(() => {
-    if (!loading && !user) navOnce("/login");
-  }, [loading, user, navOnce]);
+    if (!loading && !user) navOnce(withFrom("/login", dest));
+  }, [loading, user, navOnce, dest]);
 
-  // Auto-detect verification: already-verified on mount, a background poll, or
-  // the user returning to this tab after clicking the email link. Because
-  // emailVerified isn't live, each trigger calls reloadUser() (which coalesces
-  // concurrent calls and never throws). Tearing down on unmount / sign-out /
-  // success means no reload requests linger after the page is inactive.
+  // Auto-detect verification: already-verified on mount, a background poll, or the user
+  // returning to this tab after clicking the email link. Because emailVerified isn't live,
+  // each trigger calls reloadUser() (which coalesces concurrent calls and never throws).
+  //
+  // The interval only runs while the tab is visible — a hidden tab can't act on the result
+  // and browsers throttle its timers anyway — and only until the deadline. Focus and
+  // visibility checks stay wired up past the deadline, because those are the user showing
+  // up, which is exactly when a check is worth making.
   useEffect(() => {
     if (loading || !user) return;
     if (user.emailVerified) {
@@ -59,45 +95,120 @@ function VerifyEmail() {
       return;
     }
 
+    if (pollDeadline.current === 0) {
+      pollDeadline.current = Date.now() + VERIFY_POLL_MAX_MS;
+    }
+
     let cancelled = false;
-    const check = async () => {
-      const verified = await reloadUser();
-      if (!cancelled && verified) navOnce(dest);
+    let interval: ReturnType<typeof setInterval> | undefined;
+
+    const stop = () => {
+      if (interval !== undefined) {
+        clearInterval(interval);
+        interval = undefined;
+      }
     };
 
-    const interval = setInterval(check, VERIFY_POLL_INTERVAL_MS);
-    const onVisible = () => {
-      if (document.visibilityState === "visible") check();
+    const check = async () => {
+      if (cancelled) return;
+      const verified = await reloadUser();
+      if (cancelled || !verified) return;
+      // Stop before navigating so no further reload fires in the gap before unmount.
+      stop();
+      navOnce(dest);
     };
-    document.addEventListener("visibilitychange", onVisible);
-    window.addEventListener("focus", check);
+
+    const giveUp = () => {
+      stop();
+      exhausted.current = true;
+      setPollExhausted(true);
+    };
+
+    const start = () => {
+      if (interval !== undefined || cancelled || exhausted.current) return;
+      // The deadline can pass while the tab is hidden and the interval stopped. Catching it
+      // here means returning to the tab shows the manual control straight away rather than
+      // after one more poll.
+      if (Date.now() >= pollDeadline.current) {
+        giveUp();
+        return;
+      }
+      interval = setInterval(() => {
+        if (Date.now() >= pollDeadline.current) {
+          giveUp();
+          return;
+        }
+        void check();
+      }, VERIFY_POLL_INTERVAL_MS);
+    };
+
+    const onVisibility = () => {
+      if (document.visibilityState === "visible") {
+        void check();
+        start();
+      } else {
+        stop();
+      }
+    };
+    const onFocus = () => void check();
+
+    if (document.visibilityState === "visible") start();
+    document.addEventListener("visibilitychange", onVisibility);
+    window.addEventListener("focus", onFocus);
 
     return () => {
       cancelled = true;
-      clearInterval(interval);
-      document.removeEventListener("visibilitychange", onVisible);
-      window.removeEventListener("focus", check);
+      stop();
+      document.removeEventListener("visibilitychange", onVisibility);
+      window.removeEventListener("focus", onFocus);
     };
   }, [loading, user, reloadUser, navOnce, dest]);
 
+  // Same shape for the "sent" confirmation, so an unmount mid-notice leaves nothing behind.
+  useEffect(() => {
+    if (!resent) return;
+    const id = setTimeout(() => setResent(false), RESENT_NOTICE_MS);
+    return () => clearTimeout(id);
+  }, [resent]);
+
   const handleResend = async () => {
-    if (resending) return;
+    // Guards a double-click mid-request as well as the cooldown window.
+    if (resending || cooldown.active) return;
     setError("");
     setResending(true);
     try {
       await sendVerification();
       setResent(true);
-      setTimeout(() => setResent(false), 4000);
+      cooldown.start(RESEND_COOLDOWN_SECONDS);
     } catch (err) {
       setError(getAuthErrorMessage(err));
+      // Firebase is already refusing — start the cooldown anyway so we stop hammering it.
+      // A failure for any other reason leaves the button live for an immediate retry.
+      if (isRateLimitError(err)) cooldown.start(RESEND_COOLDOWN_SECONDS);
     } finally {
       setResending(false);
     }
   };
 
+  // Manual replacement for the poll once it has given up.
+  const handleCheckNow = async () => {
+    if (checking) return;
+    setChecking(true);
+    setCheckedNotVerified(false);
+    const verified = await reloadUser();
+    setChecking(false);
+    if (verified) navOnce(dest);
+    else setCheckedNotVerified(true);
+  };
+
   const handleSignOut = async () => {
     await signOut();
-    router.push("/login");
+    // signOut clears the persisted cart/wishlist; these reset the in-memory contexts, which
+    // live below AuthProvider and so are out of its reach.
+    clearCart();
+    clearWishlist();
+    // "Wrong email?" means a different account, not a different destination.
+    router.push(withFrom("/login", dest));
   };
 
   // Don't flash the verify UI before auth resolves or while redirecting a
@@ -128,7 +239,9 @@ function VerifyEmail() {
             className="text-ink/55"
             style={{ fontFamily: "var(--font-manrope)", fontSize: "0.88rem" }}
           >
-            We&apos;ve sent a verification link to:
+            {initialSendFailed && !resent
+              ? "Your account is ready, but we couldn't send the verification email to:"
+              : "We've sent a verification link to:"}
           </motion.p>
           <motion.p
             variants={fadeUp}
@@ -146,8 +259,9 @@ function VerifyEmail() {
             className="text-ink/45 leading-relaxed mb-7 max-w-xs"
             style={{ fontFamily: "var(--font-manrope)", fontSize: "0.8rem" }}
           >
-            Click the link in your email to activate your account and start
-            shopping.
+            {initialSendFailed && !resent
+              ? "Your account was created successfully — nothing is lost. Tap resend below to send the link."
+              : "Click the link in your email to activate your account and start shopping."}
           </motion.p>
 
           {/* Resend */}
@@ -174,20 +288,46 @@ function VerifyEmail() {
                   key="resend-btn"
                   type="button"
                   onClick={handleResend}
-                  disabled={resending}
+                  disabled={resending || cooldown.active}
                   className="btn-outline w-full disabled:opacity-60"
                 >
-                  {resending ? "Sending…" : "Resend Verification Email"}
+                  {resending
+                    ? "Sending…"
+                    : cooldown.active
+                      ? `Resend available in ${cooldown.remaining}s`
+                      : "Resend Verification Email"}
                 </motion.button>
               )}
             </AnimatePresence>
           </motion.div>
 
+          {/* Automatic checking has stopped — hand the user an explicit way to re-check. */}
+          {pollExhausted && (
+            <motion.div variants={fadeUp} className="w-full mb-3">
+              <p
+                className="text-ink/45 leading-relaxed mb-3"
+                style={{ fontFamily: "var(--font-manrope)", fontSize: "0.75rem" }}
+              >
+                {checkedNotVerified
+                  ? "Still not verified. Check your inbox, then try again."
+                  : "We've stopped checking automatically. Once you've clicked the link, check again."}
+              </p>
+              <button
+                type="button"
+                onClick={handleCheckNow}
+                disabled={checking}
+                className="btn-outline w-full disabled:opacity-60"
+              >
+                {checking ? "Checking…" : "I've verified — check again"}
+              </button>
+            </motion.div>
+          )}
+
           {showManualContinue && (
             <motion.button
               variants={fadeUp}
               type="button"
-              onClick={() => router.push(dest)}
+              onClick={() => navOnce(dest)}
               whileHover={{ scale: 1.015 }}
               whileTap={{ scale: 0.98 }}
               className="btn-primary-gradient w-full py-4"

--- a/src/app/(auth)/verify-email/VerifyEmailContent.tsx
+++ b/src/app/(auth)/verify-email/VerifyEmailContent.tsx
@@ -8,7 +8,12 @@ import { fadeUp } from "@/lib/motion";
 import { useAuth } from "@/context/AuthContext";
 import { useCart } from "@/context/CartContext";
 import { useWishlist } from "@/context/WishlistContext";
-import { requiresVerification, resolveDestination, withFrom } from "@/lib/redirect";
+import {
+  DEFAULT_DESTINATION,
+  requiresVerification,
+  resolveDestination,
+  withFrom,
+} from "@/lib/redirect";
 import AuthForm from "@/components/auth/AuthForm";
 import AuthErrorToast from "@/components/auth/AuthErrorToast";
 import { getAuthErrorMessage, isRateLimitError } from "@/lib/auth-errors";
@@ -42,6 +47,11 @@ function VerifyEmail() {
   // this page while unverified — and the verified case is already handled by the
   // auto-redirect below. So the manual CTA only makes sense for advisory destinations.
   const showManualContinue = !requiresVerification(dest);
+  // `dest` is whatever survived resolveDestination — /verify-email?from=%2Fstore is
+  // reachable from sign-up — so the label has to follow it rather than always claiming
+  // the account page while navigating somewhere else.
+  const continueLabel =
+    dest === DEFAULT_DESTINATION ? "Continue to My Account" : "Continue";
   // Sign-up sets `sent=0` when the account was created but the verification email couldn't
   // be sent. The account is real and the session is live — only the email is missing — so
   // say so plainly instead of claiming we sent something we didn't.
@@ -332,7 +342,7 @@ function VerifyEmail() {
               whileTap={{ scale: 0.98 }}
               className="btn-primary-gradient w-full py-4"
             >
-              Continue to My Account
+              {continueLabel}
             </motion.button>
           )}
 

--- a/src/app/account/AccountContent.tsx
+++ b/src/app/account/AccountContent.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { motion } from "framer-motion";
 import {
@@ -12,6 +12,16 @@ import {
 } from "lucide-react";
 import { fadeUp, staggerContainer } from "@/lib/motion";
 import { useAuth } from "@/context/AuthContext";
+import { useCart } from "@/context/CartContext";
+import { useWishlist } from "@/context/WishlistContext";
+import { sessionExpiredLoginUrl, withFrom } from "@/lib/redirect";
+import { clearSessionHint } from "@/lib/session";
+import { getAuthErrorMessage, isRateLimitError } from "@/lib/auth-errors";
+import { useCooldown } from "@/components/auth/useCooldown";
+import AuthErrorToast from "@/components/auth/AuthErrorToast";
+
+/** Matches the cooldown on /verify-email and /forgot-password. */
+const RESEND_COOLDOWN_SECONDS = 60;
 
 const cards = [
   {
@@ -38,19 +48,54 @@ const cards = [
 
 export default function AccountContent() {
   const router = useRouter();
-  const { user, loading, signOut } = useAuth();
+  const { user, loading, signOut, sendVerification } = useAuth();
+  const { clearCart } = useCart();
+  const { clearWishlist } = useWishlist();
+  const cooldown = useCooldown();
+  const [resending, setResending] = useState(false);
+  const [resent, setResent] = useState(false);
+  const [error, setError] = useState("");
 
-  // The proxy gates this route on a presence cookie only. If the Firebase session
-  // is actually gone (expired / stale cookie), bounce to login rather than render
-  // the dashboard to a logged-out visitor.
+  const handleResendVerification = async () => {
+    if (resending || cooldown.active) return;
+    setError("");
+    setResending(true);
+    try {
+      await sendVerification();
+      setResent(true);
+      cooldown.start(RESEND_COOLDOWN_SECONDS);
+    } catch (err) {
+      setError(getAuthErrorMessage(err));
+      // Already being throttled — back off rather than let them keep trying.
+      if (isRateLimitError(err)) cooldown.start(RESEND_COOLDOWN_SECONDS);
+    } finally {
+      setResending(false);
+    }
+  };
+  // One-shot guard: Strict Mode double-invokes effects and we never want two navigations
+  // racing (matches CheckoutContent).
+  const redirected = useRef(false);
+
+  // The proxy gates this route on the presence hint alone, which proves nothing. Now that
+  // Firebase has spoken, enforce the real answer: no user means the hint was stale, expired
+  // or hand-set, so clear it and bounce — carrying the destination so signing back in
+  // returns here. Clearing before navigating is what stops the proxy seeing the dead hint
+  // on /login and bouncing them straight back.
   useEffect(() => {
-    if (!loading && !user) router.replace("/login?from=/account");
+    if (loading || user || redirected.current) return;
+    redirected.current = true;
+    clearSessionHint();
+    router.replace(sessionExpiredLoginUrl("/account"));
   }, [loading, user, router]);
 
   const firstName = user?.displayName?.split(" ")[0] ?? "Beautiful";
 
   const handleSignOut = async () => {
     await signOut();
+    // signOut clears the persisted cart/wishlist; these reset the in-memory contexts, which
+    // live below AuthProvider and so are out of its reach.
+    clearCart();
+    clearWishlist();
     router.push("/");
   };
 
@@ -100,30 +145,66 @@ export default function AccountContent() {
             Welcome, {loading ? "…" : firstName}
           </motion.h1>
 
-          {/* Email verification reminder */}
+          {/* Advisory, never a gate: /account stays fully usable while unverified. The copy
+              says what verification is for, what it unlocks, and that they can carry on
+              without it — so the reminder informs rather than nags. */}
           {user && !user.emailVerified && (
             <motion.div
               variants={fadeUp}
-              className="inline-flex items-center gap-2 mt-5 px-4 py-2 rounded-full"
+              className="mt-6 mx-auto max-w-md text-left px-5 py-4 rounded-2xl"
               style={{
-                background: "rgba(201,151,122,0.1)",
+                background: "rgba(201,151,122,0.08)",
                 border: "1px solid rgba(201,151,122,0.25)",
               }}
             >
-              <Mail size={13} className="text-rose-gold" />
-              <span
-                className="text-ink/65"
+              <div className="flex items-center gap-2 mb-2">
+                <Mail size={14} className="text-rose-gold flex-shrink-0" />
+                <span
+                  className="text-ink font-medium"
+                  style={{ fontFamily: "var(--font-manrope)", fontSize: "0.82rem" }}
+                >
+                  Your email isn&apos;t verified yet
+                </span>
+              </div>
+              <p
+                className="text-ink/60 leading-relaxed mb-1"
+                style={{ fontFamily: "var(--font-manrope)", fontSize: "0.78rem" }}
+              >
+                Verifying <span className="text-ink/80">{user.email}</span> keeps your
+                account secure and is required before you can check out.
+              </p>
+              <p
+                className="text-ink/45 leading-relaxed mb-3"
                 style={{ fontFamily: "var(--font-manrope)", fontSize: "0.75rem" }}
               >
-                Please verify your email
-              </span>
-              <button
-                onClick={() => router.push("/verify-email")}
-                className="text-rose-gold font-medium hover:opacity-70"
-                style={{ fontFamily: "var(--font-manrope)", fontSize: "0.75rem" }}
-              >
-                Verify now →
-              </button>
+                Everything else here works as normal in the meantime.
+              </p>
+
+              <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
+                <button
+                  type="button"
+                  onClick={handleResendVerification}
+                  disabled={resending || cooldown.active}
+                  className="text-rose-dark font-medium hover:opacity-70 transition-opacity disabled:opacity-50"
+                  style={{ fontFamily: "var(--font-manrope)", fontSize: "0.78rem" }}
+                >
+                  {resending
+                    ? "Sending…"
+                    : resent
+                      ? "Verification email sent ✓"
+                      : cooldown.active
+                        ? `Resend in ${cooldown.remaining}s`
+                        : "Resend verification email"}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => router.push(withFrom("/verify-email", "/account"))}
+                  className="text-ink/50 hover:text-dusty-pink transition-colors"
+                  style={{ fontFamily: "var(--font-manrope)", fontSize: "0.78rem" }}
+                >
+                  Already clicked the link?
+                </button>
+              </div>
             </motion.div>
           )}
 
@@ -190,6 +271,8 @@ export default function AccountContent() {
           </button>
         </motion.div>
       </div>
+
+      <AuthErrorToast message={error} onDismiss={() => setError("")} />
     </section>
   );
 }

--- a/src/app/account/AccountContent.tsx
+++ b/src/app/account/AccountContent.tsx
@@ -23,6 +23,9 @@ import AuthErrorToast from "@/components/auth/AuthErrorToast";
 /** Matches the cooldown on /verify-email and /forgot-password. */
 const RESEND_COOLDOWN_SECONDS = 60;
 
+/** How long the "sent ✓" confirmation shows before the button returns to its normal label. */
+const RESENT_NOTICE_MS = 4000;
+
 const cards = [
   {
     Icon: ShoppingBag,
@@ -72,6 +75,15 @@ export default function AccountContent() {
       setResending(false);
     }
   };
+  // Let the confirmation lapse, otherwise `resent` outranks the cooldown in the button
+  // label forever and a second resend gives no feedback at all. Same shape as
+  // VerifyEmailContent, so an unmount mid-notice leaves no timer behind.
+  useEffect(() => {
+    if (!resent) return;
+    const id = setTimeout(() => setResent(false), RESENT_NOTICE_MS);
+    return () => clearTimeout(id);
+  }, [resent]);
+
   // One-shot guard: Strict Mode double-invokes effects and we never want two navigations
   // racing (matches CheckoutContent).
   const redirected = useRef(false);
@@ -91,6 +103,11 @@ export default function AccountContent() {
   const firstName = user?.displayName?.split(" ")[0] ?? "Beautiful";
 
   const handleSignOut = async () => {
+    // Claim the one-shot guard *before* signing out. signOut drives onAuthStateChanged →
+    // user === null, which is exactly what the expiry effect above watches for — without
+    // this it fires on the same render and its router.replace beats the push below, so
+    // deliberately signing out lands on "Your session has ended. Please sign in again".
+    redirected.current = true;
     await signOut();
     // signOut clears the persisted cart/wishlist; these reset the in-memory contexts, which
     // live below AuthProvider and so are out of its reach.

--- a/src/app/checkout/CheckoutContent.tsx
+++ b/src/app/checkout/CheckoutContent.tsx
@@ -10,6 +10,8 @@ import { fadeUp, staggerContainer } from "@/lib/motion";
 import { useAuth } from "@/context/AuthContext";
 import { useCart } from "@/context/CartContext";
 import { formatPrice } from "@/lib/format";
+import { sessionExpiredLoginUrl, withFrom } from "@/lib/redirect";
+import { clearSessionHint } from "@/lib/session";
 
 export default function CheckoutContent() {
   const router = useRouter();
@@ -25,13 +27,18 @@ export default function CheckoutContent() {
   // so the user lands back here once verified. See #22.
   useEffect(() => {
     if (loading || redirected.current) return;
+    // The full current URL, so a coupon or similar survives the round trip. withFrom
+    // validates and encodes it.
+    const dest = window.location.pathname + window.location.search;
     if (!user) {
       redirected.current = true;
-      router.replace("/login?from=checkout");
+      // The hint let us in but Firebase says otherwise — it was stale, expired or hand-set.
+      // Clear it before navigating so the proxy doesn't bounce us back off /login.
+      clearSessionHint();
+      router.replace(sessionExpiredLoginUrl(dest));
     } else if (!user.emailVerified) {
       redirected.current = true;
-      const dest = window.location.pathname + window.location.search;
-      router.replace(`/verify-email?from=${encodeURIComponent(dest)}`);
+      router.replace(withFrom("/verify-email", dest));
     }
   }, [loading, user, router]);
 

--- a/src/components/CartSidebar.tsx
+++ b/src/components/CartSidebar.tsx
@@ -9,6 +9,7 @@ import { useAuth } from "@/context/AuthContext";
 import SideDrawer from "@/components/SideDrawer";
 import { ease } from "@/lib/motion";
 import { formatPrice } from "@/lib/format";
+import { withFrom } from "@/lib/redirect";
 
 export default function CartSidebar() {
   const {
@@ -26,7 +27,7 @@ export default function CartSidebar() {
   const handleCheckout = () => {
     setCartOpen(false);
     if (!user) {
-      router.push("/login?from=checkout");
+      router.push(withFrom("/login", "/checkout"));
     } else {
       router.push("/checkout");
     }

--- a/src/components/auth/AccountExistsNotice.tsx
+++ b/src/components/auth/AccountExistsNotice.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import Link from "next/link";
+import type { MouseEvent, ReactNode } from "react";
+
+interface AccountExistsNoticeProps {
+  /** What happened, in the user's terms. */
+  children: ReactNode;
+  /** Omit on the sign-in pane — the form is already right there. */
+  signInHref?: string;
+  resetHref: string;
+  /** Lets /login and /signup intercept the sign-in link to play the blade transition. */
+  onSignIn?: (e: MouseEvent<HTMLAnchorElement>) => void;
+}
+
+/**
+ * "You already have an account" — shown inline rather than as a toast.
+ *
+ * Both cases that reach it (signing up with a taken address, and an OAuth provider clashing
+ * with an existing account) are the same situation from the user's side: they are already a
+ * customer and need a route in, not a red error that disappears after five seconds. The
+ * hrefs come from the caller so the post-auth destination survives the detour.
+ */
+export default function AccountExistsNotice({
+  children,
+  signInHref,
+  resetHref,
+  onSignIn,
+}: AccountExistsNoticeProps) {
+  return (
+    <div
+      role="status"
+      className="mt-2 px-3 py-2.5 rounded-xl"
+      style={{
+        background: "rgba(201,151,122,0.08)",
+        border: "1px solid rgba(201,151,122,0.25)",
+      }}
+    >
+      <p
+        className="text-ink/70 mb-1.5 leading-relaxed"
+        style={{ fontFamily: "var(--font-manrope)", fontSize: "0.78rem" }}
+      >
+        {children}
+      </p>
+      <div className="flex items-center gap-3">
+        {signInHref && (
+          <>
+            <Link
+              href={signInHref}
+              onClick={onSignIn}
+              className="text-rose-dark font-medium hover:opacity-70 transition-opacity"
+              style={{ fontFamily: "var(--font-manrope)", fontSize: "0.78rem" }}
+            >
+              Sign in instead
+            </Link>
+            <span className="text-ink/25" aria-hidden="true">
+              ·
+            </span>
+          </>
+        )}
+        <Link
+          href={resetHref}
+          className="text-rose-dark font-medium hover:opacity-70 transition-opacity"
+          style={{ fontFamily: "var(--font-manrope)", fontSize: "0.78rem" }}
+        >
+          Reset your password
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/components/auth/AuthErrorToast.tsx
+++ b/src/components/auth/AuthErrorToast.tsx
@@ -3,35 +3,6 @@
 import { useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { AlertCircle, X } from "lucide-react";
-import { FirebaseError } from "firebase/app";
-
-const errorMessages: Record<string, string> = {
-  "auth/email-already-in-use": "An account with this email already exists.",
-  "auth/invalid-email": "Please enter a valid email address.",
-  "auth/wrong-password": "Incorrect password. Please try again.",
-  "auth/invalid-credential": "Incorrect email or password. Please try again.",
-  "auth/user-not-found": "No account found with this email.",
-  "auth/weak-password": "Password should be at least 6 characters.",
-  "auth/too-many-requests": "Too many attempts. Please wait a moment and try again.",
-  "auth/network-request-failed": "Connection error. Please check your internet.",
-  "auth/popup-closed-by-user": "", // user cancelled — stay silent
-  "auth/cancelled-popup-request": "",
-  "auth/account-exists-with-different-credential":
-    "This email is already linked to a different sign-in method.",
-};
-
-/**
- * Translate any thrown auth error into a friendly message.
- * Returns "" for errors that should be silently ignored (e.g. cancelled popups).
- */
-export function getAuthErrorMessage(err: unknown): string {
-  if (err instanceof FirebaseError) {
-    if (err.code in errorMessages) return errorMessages[err.code];
-    return "Something went wrong. Please try again.";
-  }
-  if (err instanceof Error && err.message) return err.message;
-  return "Something went wrong. Please try again.";
-}
 
 interface AuthErrorToastProps {
   message: string;

--- a/src/components/auth/SignInPane.tsx
+++ b/src/components/auth/SignInPane.tsx
@@ -6,6 +6,8 @@ import { motion } from "framer-motion";
 import { Eye, EyeOff } from "lucide-react";
 import { fadeUp } from "@/lib/motion";
 import { cn } from "@/lib/utils";
+import { withFrom } from "@/lib/redirect";
+import AccountExistsNotice from "./AccountExistsNotice";
 import AuthForm from "./AuthForm";
 import FloatingInput from "./FloatingInput";
 import SocialAuthButtons from "./SocialAuthButtons";
@@ -21,6 +23,13 @@ interface SignInPaneProps {
   remember: boolean;
   onRememberChange: (value: boolean) => void;
   loading: boolean;
+  /**
+   * A social sign-in clashed with an existing account. The string is the conflicting
+   * address (empty when Firebase didn't supply one); `null` means no conflict.
+   */
+  credentialConflict?: string | null;
+  /** Arrived here because a protected page found the session gone. */
+  sessionExpired?: boolean;
   onSubmit: (e: React.FormEvent) => void;
   onGoogle: () => Promise<void>;
   onApple: () => Promise<void>;
@@ -36,11 +45,21 @@ export default function SignInPane({
   remember,
   onRememberChange,
   loading,
+  credentialConflict = null,
+  sessionExpired = false,
   onSubmit,
   onGoogle,
   onApple,
 }: SignInPaneProps) {
-  const { requestSwitch, isTransitioning, notifyPaneReady } = useAuthTransition();
+  const { requestSwitch, isTransitioning, notifyPaneReady, lastLoginFrom } =
+    useAuthTransition();
+
+  // Carry the post-auth destination onto the sibling auth routes. withFrom validates, so a
+  // poisoned value can never be serialised into these hrefs. /forgot-password especially
+  // needs it on the URL: it renders outside the (card) group, so AuthCard unmounts and the
+  // context value is gone by the time the user comes back.
+  const signUpHref = withFrom("/signup", lastLoginFrom);
+  const forgotHref = withFrom("/forgot-password", lastLoginFrom);
 
   // Tell the blade this pane is up. The effect runs post-commit, so the pane is
   // already mounted here; the rAF then guarantees it has *painted* before the
@@ -53,7 +72,38 @@ export default function SignInPane({
 
   return (
     <AuthForm title="Welcome Back" subtitle="Sign in to your account">
+      {/* Not an error — a plain explanation, above the form, in the calm brand tint rather
+          than the red used for things the user got wrong. */}
+      {sessionExpired && (
+        <div
+          role="status"
+          className="mb-5 px-3 py-2.5 rounded-xl"
+          style={{
+            background: "rgba(201,151,122,0.08)",
+            border: "1px solid rgba(201,151,122,0.25)",
+          }}
+        >
+          <p
+            className="text-ink/70 leading-relaxed"
+            style={{ fontFamily: "var(--font-manrope)", fontSize: "0.78rem" }}
+          >
+            Your session has ended. Please sign in again — we&apos;ll take you straight back
+            to where you were.
+          </p>
+        </div>
+      )}
+
       <SocialAuthButtons onGoogle={onGoogle} onApple={onApple} dividerLabel="or sign in with email" />
+
+      {/* Google/Apple refused because the address belongs to an account made another way.
+          Sits directly under the social buttons — that's what the user just pressed. */}
+      {credentialConflict !== null && (
+        <AccountExistsNotice resetHref={forgotHref}>
+          {credentialConflict || "That email"} already has an account created with a
+          different sign-in method. Try signing in with your email and password below, or
+          reset your password if you don&apos;t remember it.
+        </AccountExistsNotice>
+      )}
 
       <form onSubmit={onSubmit} className="flex flex-col gap-4">
         <FloatingInput
@@ -102,7 +152,7 @@ export default function SignInPane({
             </span>
           </label>
           <Link
-            href="/forgot-password"
+            href={forgotHref}
             className="text-rose-dark hover:opacity-70 transition-opacity"
             style={{ fontFamily: "var(--font-manrope)", fontSize: "0.78rem" }}
           >
@@ -132,11 +182,11 @@ export default function SignInPane({
             route is reachable without JS; the click handler takes over to play
             the blade sweep instead of a plain navigation. */}
         <Link
-          href="/signup"
+          href={signUpHref}
           onClick={(e) => {
             if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) return;
             e.preventDefault();
-            requestSwitch("signup", "/signup");
+            requestSwitch("signup", signUpHref);
           }}
           aria-disabled={isTransitioning || undefined}
           className={cn(

--- a/src/components/auth/SignUpPane.tsx
+++ b/src/components/auth/SignUpPane.tsx
@@ -6,20 +6,22 @@ import { motion } from "framer-motion";
 import { Eye, EyeOff } from "lucide-react";
 import { fadeUp } from "@/lib/motion";
 import { cn } from "@/lib/utils";
+import { withFrom } from "@/lib/redirect";
+import { MIN_PASSWORD_LENGTH } from "@/lib/constants";
+import {
+  PASSWORD_STRENGTH_COLOR,
+  PASSWORD_STRENGTH_LABEL,
+  PASSWORD_STRENGTH_SEGMENTS,
+  type PasswordStrength,
+} from "@/lib/password";
+import AccountExistsNotice from "./AccountExistsNotice";
 import AuthForm from "./AuthForm";
 import FloatingInput from "./FloatingInput";
 import SocialAuthButtons from "./SocialAuthButtons";
 import { useAuthTransition } from "./AuthTransitionContext";
 
-/**
- * Weak → strong stays a semantic progression (it's a usability signal, not
- * decoration — same reason inline field errors stay red), but each stop is
- * re-tinted from the brand palette so it doesn't read as an off-the-shelf meter.
- * "Strong" lands on an emerald tint, a nod to dark-emerald as the supporting
- * contrast colour.
- */
-export const STRENGTH_LABELS = ["Weak", "Fair", "Good", "Strong"];
-export const STRENGTH_COLORS = ["#d97b6c", "#dba15a", "#c9977a", "#5c7350"];
+/** Strength scale, labels and tints live in @/lib/password — see the note there on why
+ *  it's three states and not four. */
 
 interface SignUpPaneProps {
   name: string;
@@ -34,9 +36,16 @@ interface SignUpPaneProps {
   onTogglePassword: () => void;
   agreed: boolean;
   onAgreedChange: (value: boolean) => void;
-  strength: number;
+  strength: PasswordStrength;
   loading: boolean;
-  fieldErrors: { password?: string; confirm?: string; agree?: string };
+  fieldErrors: { email?: string; password?: string; confirm?: string; agree?: string };
+  /** Firebase refused because this address already has an account. */
+  emailAlreadyInUse?: boolean;
+  /**
+   * A social sign-in clashed with an existing account. The string is the conflicting
+   * address (empty when Firebase didn't supply one); `null` means no conflict.
+   */
+  credentialConflict?: string | null;
   onSubmit: (e: React.FormEvent) => void;
   onGoogle: () => Promise<void>;
   onApple: () => Promise<void>;
@@ -58,6 +67,8 @@ export default function SignUpPane({
   strength,
   loading,
   fieldErrors,
+  emailAlreadyInUse = false,
+  credentialConflict = null,
   onSubmit,
   onGoogle,
   onApple,
@@ -70,9 +81,16 @@ export default function SignUpPane({
   }, [notifyPaneReady]);
 
   // Carry the destination back if the user arrived here from /login?from=…
-  const signInHref = lastLoginFrom
-    ? `/login?from=${encodeURIComponent(lastLoginFrom)}`
-    : "/login";
+  // withFrom does the validating and encoding, so this stays inside the one boundary.
+  const signInHref = withFrom("/login", lastLoginFrom);
+  const resetHref = withFrom("/forgot-password", lastLoginFrom);
+
+  // Keep the blade sweep for in-app switches, but let modified clicks open a new tab.
+  const switchToSignIn = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) return;
+    e.preventDefault();
+    requestSwitch("signin", signInHref);
+  };
 
   return (
     <AuthForm title="Begin Your Journey" subtitle="Create your account">
@@ -86,15 +104,32 @@ export default function SignUpPane({
           required
         />
 
-        <FloatingInput
-          id="email"
-          label="Email Address"
-          type="email"
-          value={email}
-          onChange={(e) => onEmailChange(e.target.value)}
-          autoComplete="email"
-          required
-        />
+        <div>
+          <FloatingInput
+            id="email"
+            label="Email Address"
+            type="email"
+            value={email}
+            onChange={(e) => onEmailChange(e.target.value)}
+            autoComplete="email"
+            required
+            error={fieldErrors.email}
+          />
+
+          {/* Already registered isn't a failure — it means they're a customer already, so
+              point at the two things that actually help rather than a red toast. */}
+          {(emailAlreadyInUse || credentialConflict !== null) && (
+            <AccountExistsNotice
+              signInHref={signInHref}
+              resetHref={resetHref}
+              onSignIn={switchToSignIn}
+            >
+              {credentialConflict !== null
+                ? `${credentialConflict || "That email"} already has an account created with a different sign-in method. Please sign in the way you first signed up.`
+                : "You already have an account with this email."}
+            </AccountExistsNotice>
+          )}
+        </div>
 
         <div>
           <FloatingInput
@@ -119,30 +154,44 @@ export default function SignUpPane({
           />
 
           {password.length > 0 && (
-            <div className="flex items-center gap-2 mt-2 ml-1">
-              <div className="flex gap-1 flex-1">
-                {[0, 1, 2, 3].map((i) => (
-                  <div
-                    key={i}
-                    className="h-1 flex-1 rounded-full transition-colors duration-300"
-                    style={{
-                      background:
-                        i < strength ? STRENGTH_COLORS[strength - 1] : "rgba(232,220,208,1)",
-                    }}
-                  />
-                ))}
+            <>
+              <div className="flex items-center gap-2 mt-2 ml-1">
+                <div className="flex gap-1 flex-1">
+                  {[0, 1, 2].map((i) => (
+                    <div
+                      key={i}
+                      className="h-1 flex-1 rounded-full transition-colors duration-300"
+                      style={{
+                        background:
+                          i < PASSWORD_STRENGTH_SEGMENTS[strength]
+                            ? PASSWORD_STRENGTH_COLOR[strength]
+                            : "rgba(232,220,208,1)",
+                      }}
+                    />
+                  ))}
+                </div>
+                <span
+                  className="text-[10px] font-medium"
+                  style={{
+                    fontFamily: "var(--font-manrope)",
+                    color: PASSWORD_STRENGTH_COLOR[strength],
+                    minWidth: "62px",
+                  }}
+                >
+                  {PASSWORD_STRENGTH_LABEL[strength]}
+                </span>
               </div>
-              <span
-                className="text-[10px] font-medium"
-                style={{
-                  fontFamily: "var(--font-manrope)",
-                  color: strength > 0 ? STRENGTH_COLORS[strength - 1] : "transparent",
-                  minWidth: "38px",
-                }}
-              >
-                {strength > 0 ? STRENGTH_LABELS[strength - 1] : ""}
-              </span>
-            </div>
+              {/* Say the rule out loud while it's unmet — the meter alone doesn't tell you
+                  what to do, and this is the only thing that actually blocks submission. */}
+              {strength === "too-short" && !fieldErrors.password && (
+                <p
+                  className="mt-1.5 ml-1 text-ink/45"
+                  style={{ fontFamily: "var(--font-manrope)", fontSize: "0.72rem" }}
+                >
+                  Use at least {MIN_PASSWORD_LENGTH} characters.
+                </p>
+              )}
+            </>
           )}
         </div>
 

--- a/src/components/auth/useCooldown.ts
+++ b/src/components/auth/useCooldown.ts
@@ -1,0 +1,32 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+/**
+ * A seconds countdown for rate-limited actions — resending a verification email, requesting
+ * another password reset link.
+ *
+ * A chained `setTimeout` rather than an interval: it re-arms once per tick and clears on
+ * every render pass, so it can't outlive the component or double up under Strict Mode.
+ *
+ * Returns the remaining seconds (0 when idle) and a `start` to begin the countdown.
+ */
+export function useCooldown(): {
+  remaining: number;
+  active: boolean;
+  start: (seconds: number) => void;
+  reset: () => void;
+} {
+  const [remaining, setRemaining] = useState(0);
+
+  useEffect(() => {
+    if (remaining <= 0) return;
+    const id = setTimeout(() => setRemaining((value) => value - 1), 1000);
+    return () => clearTimeout(id);
+  }, [remaining]);
+
+  const start = useCallback((seconds: number) => setRemaining(seconds), []);
+  const reset = useCallback(() => setRemaining(0), []);
+
+  return { remaining, active: remaining > 0, start, reset };
+}

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -214,6 +214,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   );
 
   const socialSignIn = useCallback(async (provider: FirebaseAuthProvider) => {
+    // State the intent instead of inheriting it. There's no "remember me" on the social
+    // buttons, so these logins are persistent — but without saying so we'd keep whatever
+    // persistence a previous signIn left on the Auth instance, while signOut has already
+    // cleared the session-only marker. That pairs a session-scoped Firebase login with a
+    // 30-day hint cookie, and the next browser launch bounces off /account as "expired".
+    markSessionOnly(false);
+    await setPersistence(auth, browserLocalPersistence);
     try {
       const result = await signInWithPopup(auth, provider);
       setSessionHint();

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -23,18 +23,46 @@ import {
   sendPasswordResetEmail,
   sendEmailVerification,
   updateProfile,
+  getAdditionalUserInfo,
   type User,
+  type UserCredential,
   type AuthProvider as FirebaseAuthProvider,
 } from "firebase/auth";
-import { FirebaseError } from "firebase/app";
 import { auth, googleProvider, appleProvider } from "@/lib/firebase";
-import { AUTH_COOKIE } from "@/lib/constants";
+import { isPopupFallbackError, isUserNotFoundError } from "@/lib/auth-errors";
+import { normalizeEmail } from "@/lib/email";
+import { readProviderName } from "@/lib/provider-profile";
+import {
+  clearLocalUserState,
+  clearSessionHint,
+  markSessionOnly,
+  setSessionHint,
+} from "@/lib/session";
+
+/**
+ * What happened *after* the account was created.
+ *
+ * `signUp` only rejects when the account could not be created at all. Once Firebase has the
+ * account, every later step is best-effort and reported here instead of thrown — telling
+ * someone "sign-up failed" when their account exists sends them back to try again, straight
+ * into `auth/email-already-in-use`, with no idea they already have an account.
+ */
+export interface SignUpResult {
+  /** False when the verification email couldn't be sent. The user can resend. */
+  verificationEmailSent: boolean;
+  /** False when the display name couldn't be saved. Cosmetic; the account is fine. */
+  displayNameSet: boolean;
+}
 
 interface AuthContextType {
   user: User | null;
   loading: boolean;
   signIn: (email: string, password: string, remember?: boolean) => Promise<void>;
-  signUp: (email: string, password: string, displayName: string) => Promise<void>;
+  signUp: (
+    email: string,
+    password: string,
+    displayName: string
+  ) => Promise<SignUpResult>;
   signOut: () => Promise<void>;
   signInWithGoogle: () => Promise<void>;
   signInWithApple: () => Promise<void>;
@@ -43,19 +71,40 @@ interface AuthContextType {
   /** Reloads the Firebase user and returns the fresh `emailVerified`. Resilient:
    *  returns false (never throws) on failure, and coalesces concurrent calls. */
   reloadUser: () => Promise<boolean>;
+  /**
+   * Error from a completed `signInWithRedirect` round trip. The redirect fallback lands the
+   * user back on the auth page with the failure already in the past, so it's held here for
+   * the page to render once and then clear.
+   */
+  redirectError: unknown;
+  clearRedirectError: () => void;
 }
 
-/** Lightweight presence flag read by the proxy. Not a credential. */
-function setAuthCookie() {
-  if (typeof document === "undefined") return;
-  const secure = location.protocol === "https:" ? "; Secure" : "";
-  document.cookie = `${AUTH_COOKIE}=1; path=/; max-age=2592000; SameSite=Lax${secure}`;
-}
+/**
+ * Persists the name a provider gave us, at the one moment it is available.
+ *
+ * This exists for Apple. Apple releases the user's real name **only on the very first
+ * authorization** — every subsequent sign-in omits it, and the only way to make it reappear
+ * is for the user to revoke the app under Settings → Apple ID → Sign in with Apple. Firebase
+ * surfaces it on the returned credential but does not reliably write it to the account
+ * record, so if we don't capture it here the name is gone for good and the account shows
+ * "Beautiful" forever.
+ *
+ * Scoped to new users because that is exactly when the name arrives; a returning Apple user
+ * carries nothing to capture. Failure is cosmetic and never blocks sign-in.
+ */
+async function captureProviderDisplayName(result: UserCredential): Promise<void> {
+  const info = getAdditionalUserInfo(result);
+  if (!info?.isNewUser) return;
 
-function clearAuthCookie() {
-  if (typeof document === "undefined") return;
-  const secure = location.protocol === "https:" ? "; Secure" : "";
-  document.cookie = `${AUTH_COOKIE}=; path=/; max-age=0; SameSite=Lax${secure}`;
+  const name = readProviderName(info.profile, result.user.displayName);
+  if (!name) return;
+
+  try {
+    await updateProfile(result.user, { displayName: name });
+  } catch (err) {
+    console.error("Failed to persist provider display name:", err);
+  }
 }
 
 const AuthContext = createContext<AuthContextType | null>(null);
@@ -67,6 +116,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   // freshly-mutated `user.emailVerified` (reload() mutates currentUser in place
   // and does not fire onAuthStateChanged).
   const [, setTick] = useState(0);
+  const [redirectError, setRedirectError] = useState<unknown>(null);
   // Holds the active reload so overlapping callers (poll + tab-focus) share one
   // in-flight request instead of firing concurrent reload()s.
   const reloadInFlight = useRef<Promise<boolean> | null>(null);
@@ -77,17 +127,26 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     // and its errors are swallowed. onAuthStateChanged still fires for the success
     // case, but this surfaces redirect-stage failures.
     getRedirectResult(auth)
-      .then((result) => {
-        if (result?.user) setAuthCookie();
+      .then(async (result) => {
+        if (!result?.user) return;
+        setSessionHint();
+        await captureProviderDisplayName(result);
       })
       .catch((err) => {
+        // Hand it to the UI as well as the console. The redirect fallback returns the user
+        // to the auth page with no idea anything went wrong; a silent failure here reads as
+        // "the button did nothing", which is how the popup-blocked path used to feel.
         console.error("Social sign-in (redirect) failed:", err);
+        setRedirectError(err);
       });
 
+    // Firebase auth state is the authority; the hint cookie is reconciled to it on every
+    // transition. A hint that outlives its session (expiry, revoked refresh token, a value
+    // set by hand) is cleared here the moment Firebase reports no user.
     const unsub = onAuthStateChanged(auth, (u) => {
       setUser(u);
-      if (u) setAuthCookie();
-      else clearAuthCookie();
+      if (u) setSessionHint();
+      else clearSessionHint();
       setLoading(false);
     });
     return () => unsub();
@@ -95,52 +154,89 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const signIn = useCallback(
     async (email: string, password: string, remember = true) => {
-      // "Remember me" controls whether the Firebase session survives a browser
-      // restart. The presence cookie is reconciled by onAuthStateChanged on load.
+      // "Remember me" controls whether the Firebase session survives a browser restart.
+      // Record the choice *before* signing in so the hint cookie written below (and on any
+      // later reload) is given the matching lifetime instead of a blanket 30 days.
+      markSessionOnly(!remember);
       await setPersistence(
         auth,
         remember ? browserLocalPersistence : browserSessionPersistence
       );
-      await signInWithEmailAndPassword(auth, email, password);
-      setAuthCookie();
+      await signInWithEmailAndPassword(auth, normalizeEmail(email), password);
+      setSessionHint();
     },
     []
   );
 
   const signUp = useCallback(
-    async (email: string, password: string, displayName: string) => {
-      const cred = await createUserWithEmailAndPassword(auth, email, password);
-      // The account now exists — set the session flag before anything that can
-      // fail, so a verification-send hiccup (e.g. rate limit) doesn't strand a
-      // created account with no session and a "email already in use" on retry.
-      setAuthCookie();
+    async (
+      email: string,
+      password: string,
+      displayName: string
+    ): Promise<SignUpResult> => {
+      // The only critical step. If this rejects, no account exists and the caller should
+      // show the error and let the user fix it.
+      const cred = await createUserWithEmailAndPassword(
+        auth,
+        normalizeEmail(email),
+        password
+      );
+
+      // --- Past this line the account EXISTS. Nothing below may reject. ---
+      // Set the session flag first, so a later hiccup can't strand a created account with
+      // no session and an "email already in use" on retry.
+      setSessionHint();
+
+      let displayNameSet = true;
       if (displayName) {
-        await updateProfile(cred.user, { displayName });
+        try {
+          await updateProfile(cred.user, { displayName });
+        } catch (err) {
+          // Cosmetic. Previously this was unguarded, so a failure here rejected signUp and
+          // told the user their sign-up had failed when the account was already created.
+          displayNameSet = false;
+          console.error("Failed to set display name:", err);
+        }
       }
+
+      let verificationEmailSent = true;
       try {
         await sendEmailVerification(cred.user);
       } catch (err) {
-        // Non-fatal: the user can resend from /verify-email.
+        // Recoverable: the user can resend from /verify-email, which says so when told.
+        verificationEmailSent = false;
         console.error("Failed to send verification email:", err);
       }
+
+      return { displayNameSet, verificationEmailSent };
     },
     []
   );
 
   const socialSignIn = useCallback(async (provider: FirebaseAuthProvider) => {
     try {
-      await signInWithPopup(auth, provider);
-      setAuthCookie();
+      const result = await signInWithPopup(auth, provider);
+      setSessionHint();
+      await captureProviderDisplayName(result);
     } catch (err) {
       // On mobile / strict browsers the popup is often blocked — fall back to redirect.
-      if (
-        err instanceof FirebaseError &&
-        (err.code === "auth/popup-blocked" ||
-          err.code === "auth/operation-not-supported-in-this-environment")
-      ) {
+      // Cancellations (auth/popup-closed-by-user, auth/cancelled-popup-request) deliberately
+      // fall through to the throw: the user chose to stop, and bouncing them into a
+      // full-page redirect instead would ignore that.
+      if (isPopupFallbackError(err)) {
         await signInWithRedirect(auth, provider);
         return;
       }
+      //
+      // FUTURE — account linking (deliberately not built here):
+      // On auth/account-exists-with-different-credential the pending credential is still
+      // recoverable at this point via `OAuthProvider.credentialFromError(err)` (Apple) or
+      // `GoogleAuthProvider.credentialFromError(err)` (Google). A linking flow would hold
+      // it, sign the user in with their existing method, then call
+      // `linkWithCredential(auth.currentUser, pending)`. We don't retain it today on
+      // purpose: an unused OAuth credential parked in memory or storage is a liability, and
+      // linking needs a reauthentication story (see Phase 10) before it's safe to ship.
+      // Nothing here forecloses it — the error reaches the caller intact.
       throw err;
     }
   }, []);
@@ -156,12 +252,40 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   );
 
   const signOut = useCallback(async () => {
-    await fbSignOut(auth);
-    clearAuthCookie();
+    try {
+      await fbSignOut(auth);
+    } finally {
+      // Clear the local traces even if the Firebase call failed (offline, transient
+      // error). The user asked to leave — leaving a live hint and a populated bag behind
+      // on their device would be the worse outcome, and onAuthStateChanged reconciles the
+      // rest once connectivity returns.
+      //
+      // NOTE: this clears cart/wishlist *storage*. The in-memory contexts live below
+      // AuthProvider, so their call sites reset those (AccountContent, VerifyEmailContent).
+      clearLocalUserState();
+    }
   }, []);
 
+  /**
+   * Sends a password reset link.
+   *
+   * Resolves normally when the address has no account. Letting `auth/user-not-found` reach
+   * the UI would turn this form into a membership oracle: type an address, learn from the
+   * error whether that person shops here. Swallowing it *here* rather than in the component
+   * means no future caller can reintroduce the leak by handling the error differently.
+   *
+   * Firebase's own email-enumeration protection already collapses this case when enabled,
+   * but it's a project setting we don't control from the code, so we don't rely on it.
+   * Everything else — network failure, rate limiting — still rejects and is worth telling
+   * the user about, because none of it depends on whether the account exists.
+   */
   const resetPassword = useCallback(async (email: string) => {
-    await sendPasswordResetEmail(auth, email);
+    try {
+      await sendPasswordResetEmail(auth, normalizeEmail(email));
+    } catch (err) {
+      if (isUserNotFoundError(err)) return;
+      throw err;
+    }
   }, []);
 
   const sendVerification = useCallback(async () => {
@@ -169,6 +293,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       await sendEmailVerification(auth.currentUser);
     }
   }, []);
+
+  const clearRedirectError = useCallback(() => setRedirectError(null), []);
 
   const reloadUser = useCallback(async () => {
     if (reloadInFlight.current) return reloadInFlight.current;
@@ -211,6 +337,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         resetPassword,
         sendVerification,
         reloadUser,
+        redirectError,
+        clearRedirectError,
       }}
     >
       {children}
@@ -225,13 +353,15 @@ export function useAuth() {
       user: null,
       loading: true,
       signIn: async (_email: string, _password: string, _remember?: boolean) => {},
-      signUp: async () => {},
+      signUp: async () => ({ verificationEmailSent: false, displayNameSet: false }),
       signOut: async () => {},
       signInWithGoogle: async () => {},
       signInWithApple: async () => {},
       resetPassword: async () => {},
       sendVerification: async () => {},
       reloadUser: async () => false,
+      redirectError: null,
+      clearRedirectError: () => {},
     } satisfies AuthContextType;
   }
   return ctx;

--- a/src/context/CartContext.tsx
+++ b/src/context/CartContext.tsx
@@ -10,7 +10,7 @@ import {
   type ReactNode,
 } from "react";
 
-const STORAGE_KEY = "hb-cart";
+import { CART_STORAGE_KEY as STORAGE_KEY } from "@/lib/constants";
 
 export interface CartProduct {
   /** Namespaced key, e.g. "product:1" or "bundle:glow" — never a bare number. */

--- a/src/context/WishlistContext.tsx
+++ b/src/context/WishlistContext.tsx
@@ -8,7 +8,7 @@ import {
   type ReactNode,
 } from "react";
 
-const STORAGE_KEY = "hb-wishlist";
+import { WISHLIST_STORAGE_KEY as STORAGE_KEY } from "@/lib/constants";
 
 export interface WishlistProduct {
   /** Namespaced key, e.g. "product:1" — matches the cart's id scheme. */

--- a/src/lib/auth-errors.ts
+++ b/src/lib/auth-errors.ts
@@ -1,0 +1,188 @@
+import { MIN_PASSWORD_LENGTH } from "@/lib/constants";
+
+/**
+ * The one place Firebase auth error codes are interpreted.
+ *
+ * Everything user-facing goes through `getAuthErrorMessage`; anything that needs to *branch*
+ * on a specific failure uses a named predicate from this file rather than reaching for a
+ * raw `err.code` comparison. That keeps a code like `auth/user-not-found` — which is an
+ * account-enumeration oracle (see Phase 7) — from being re-interpreted somewhere else with
+ * a message that gives the game away.
+ *
+ * Note there is no `firebase/app` import and no `instanceof FirebaseError`. The shape is
+ * duck-typed instead: an object with a string `code` beginning `auth/`. `instanceof` breaks
+ * when a bundle ends up with two copies of the Firebase SDK — a real and very confusing
+ * failure mode — and this check can't. It also keeps the module free of SDK imports, so it
+ * is pure, cheap and directly testable.
+ */
+
+interface AuthErrorShape {
+  code: string;
+  customData?: { email?: unknown } | undefined;
+}
+
+function asAuthError(err: unknown): AuthErrorShape | null {
+  if (typeof err !== "object" || err === null) return null;
+  const code = (err as { code?: unknown }).code;
+  if (typeof code !== "string" || !code.startsWith("auth/")) return null;
+  return err as AuthErrorShape;
+}
+
+/** The raw code, for diagnostics and tests. Never shown to a user. */
+export function authErrorCode(err: unknown): string | null {
+  return asAuthError(err)?.code ?? null;
+}
+
+const GENERIC_MESSAGE = "Something went wrong. Please try again.";
+
+/**
+ * Codes the user should never see a message for, because they *are* the user's decision:
+ * they closed the popup, or opened a second one. Surfacing an error for a deliberate
+ * cancellation reads as a malfunction. `auth/popup-blocked` is here too — it's handled by
+ * silently falling back to a full-page redirect, so there is nothing to report.
+ */
+const SILENT_CODES = new Set([
+  "auth/popup-closed-by-user",
+  "auth/cancelled-popup-request",
+  "auth/popup-blocked",
+  "auth/user-cancelled",
+]);
+
+/**
+ * These three must stay identical. "Incorrect password" confirms an account exists and
+ * "no account found" confirms it doesn't — either turns the sign-in form into a membership
+ * oracle. One indistinguishable answer closes that. Do not split them.
+ */
+const CREDENTIAL_MESSAGE = "Incorrect email or password. Please try again.";
+
+const MESSAGES: Record<string, string> = {
+  // --- credentials (deliberately indistinguishable) ---
+  "auth/invalid-credential": CREDENTIAL_MESSAGE,
+  "auth/wrong-password": CREDENTIAL_MESSAGE,
+  "auth/user-not-found": CREDENTIAL_MESSAGE,
+
+  // --- input the user can fix ---
+  "auth/invalid-email": "Please enter a valid email address.",
+  "auth/missing-password": "Please enter your password.",
+  "auth/missing-email": "Please enter your email address.",
+  "auth/email-already-in-use": "An account with this email already exists.",
+  "auth/weak-password": `Please choose a password of at least ${MIN_PASSWORD_LENGTH} characters.`,
+
+  // --- account state ---
+  "auth/user-disabled": "This account has been disabled. Please contact support.",
+  "auth/account-exists-with-different-credential":
+    "An account already exists for this email. Please sign in using the method you first signed up with.",
+  "auth/requires-recent-login":
+    "For your security, please sign in again before making this change.",
+
+  // --- provider linking (see docs/auth-account-management.md) ---
+  // No caller yet. They live here so the linking work lands in one place instead of
+  // sprouting the scattered `err.code` checks this module exists to prevent.
+  "auth/credential-already-in-use":
+    "That account is already connected to a different Hey Beautiful account.",
+  "auth/provider-already-linked":
+    "That sign-in method is already connected to your account.",
+  "auth/no-such-provider":
+    "That sign-in method isn't connected to your account.",
+
+  // --- one-time links (verification / password reset) ---
+  "auth/invalid-action-code":
+    "That link is no longer valid. Please request a new one.",
+  "auth/expired-action-code":
+    "That link has expired. Please request a new one.",
+
+  // --- transient / environmental ---
+  "auth/too-many-requests":
+    "Too many attempts. Please wait a moment and try again.",
+  "auth/network-request-failed":
+    "Connection error. Please check your internet and try again.",
+  "auth/web-storage-unsupported":
+    "Your browser is blocking the storage we need to sign you in. Try turning off private browsing or third-party cookie blocking.",
+
+  // --- misconfiguration: say nothing about *what* is misconfigured ---
+  "auth/operation-not-allowed": "That sign-in method isn't available right now.",
+  "auth/unauthorized-domain": "Sign-in isn't available from this address.",
+  "auth/internal-error": GENERIC_MESSAGE,
+};
+
+/**
+ * Turns any thrown value into something safe to show a user.
+ *
+ * Returns `""` for cancellations the UI should stay quiet about — callers check for the
+ * empty string rather than assuming every failure deserves a toast.
+ */
+export function getAuthErrorMessage(err: unknown): string {
+  const authError = asAuthError(err);
+  if (!authError) {
+    // Deliberately does NOT fall back to `err.message`. A stray TypeError from our own code
+    // would otherwise be rendered verbatim in the UI, leaking internals and reading as
+    // gibberish. Unknown failures get the generic line; the console keeps the detail.
+    if (err) console.error("Unmapped auth failure:", err);
+    return GENERIC_MESSAGE;
+  }
+
+  if (SILENT_CODES.has(authError.code)) return "";
+
+  const message = MESSAGES[authError.code];
+  if (message) return message;
+
+  // A Firebase code we haven't mapped. The user gets the generic line; the code goes to the
+  // console so it can be added here rather than silently ignored forever.
+  console.warn(`Unmapped Firebase auth code: ${authError.code}`);
+  return GENERIC_MESSAGE;
+}
+
+/** True when the failure is a deliberate cancellation the UI should not report. */
+export function isSilentAuthError(err: unknown): boolean {
+  const code = authErrorCode(err);
+  return code !== null && SILENT_CODES.has(code);
+}
+
+/** Firebase refused because the caller is going too fast — back off rather than retry. */
+export function isRateLimitError(err: unknown): boolean {
+  return authErrorCode(err) === "auth/too-many-requests";
+}
+
+/** Sign-up refused: the address already has an account. */
+export function isEmailInUseError(err: unknown): boolean {
+  return authErrorCode(err) === "auth/email-already-in-use";
+}
+
+/** A social sign-in clashed with an account created via a different provider. */
+export function isCredentialConflictError(err: unknown): boolean {
+  return authErrorCode(err) === "auth/account-exists-with-different-credential";
+}
+
+/**
+ * No account for this address. Callers must be careful: surfacing this distinctly is an
+ * enumeration oracle, which is why `resetPassword` swallows it entirely.
+ */
+export function isUserNotFoundError(err: unknown): boolean {
+  return authErrorCode(err) === "auth/user-not-found";
+}
+
+/**
+ * Whether a popup attempt failed for an environmental reason worth retrying as a full-page
+ * redirect. Cancellations are excluded on purpose — the user chose to stop, and bouncing
+ * them into a redirect would override that.
+ */
+export function isPopupFallbackError(err: unknown): boolean {
+  const code = authErrorCode(err);
+  return (
+    code === "auth/popup-blocked" ||
+    code === "auth/operation-not-supported-in-this-environment"
+  );
+}
+
+/**
+ * The address behind a credential conflict, when Firebase supplied one.
+ *
+ * Safe to show back to this user: they just authenticated with a provider *for that
+ * address*, so it reveals nothing they didn't supply. We stop there and never look up which
+ * providers the account has — `fetchSignInMethodsForEmail` is the same enumeration surface
+ * Phase 7 closed, and enumeration protection makes it useless anyway.
+ */
+export function getConflictEmail(err: unknown): string | null {
+  const email = asAuthError(err)?.customData?.email;
+  return typeof email === "string" && email.length > 0 ? email : null;
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,2 +1,30 @@
-export const AUTH_COOKIE = "hb-auth-token";
+/**
+ * Presence hint read by the edge proxy so it can route without a round trip to Firebase.
+ *
+ * Its value is the literal "1". It is **not** a credential, carries no identity, and must
+ * never be treated as proof of authentication or authorization — a visitor can set it by
+ * hand from the console. Firebase auth state (and, once there is a server, a verified ID
+ * token) is the only authority. Everything protected re-checks the real session
+ * client-side; see `src/lib/session.ts` and the guards in `AccountContent` / `CheckoutContent`.
+ */
+export const SESSION_HINT_COOKIE = "hb-session-hint";
+
+/**
+ * Previous name of the hint cookie, kept only so the proxy still recognises browsers that
+ * have one from before the rename and sign-out can clear the orphan. Safe to delete once
+ * the old cookie's 30-day max-age has lapsed for everyone.
+ */
+export const LEGACY_SESSION_HINT_COOKIE = "hb-auth-token";
+
 export const REDIRECT_KEY = "hb-redirect-destination";
+
+/**
+ * Enforced password floor. Firebase's own minimum is 6; 8 is the widely recognised baseline
+ * and costs the user nothing. Lives here because both the signup validation and the
+ * `auth/weak-password` message quote it, and those two drifting apart would be confusing.
+ */
+export const MIN_PASSWORD_LENGTH = 8;
+
+/** Cart and wishlist persistence keys. Cleared on sign-out — see `clearLocalUserState`. */
+export const CART_STORAGE_KEY = "hb-cart";
+export const WISHLIST_STORAGE_KEY = "hb-wishlist";

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,0 +1,24 @@
+/**
+ * Trim surrounding whitespace and lowercase the address.
+ *
+ * Firebase stores addresses lowercased, so `A@X.com` and `a@x.com` are already the same
+ * account to it. Normalising on our side keeps every flow — sign in, sign up, password
+ * reset — agreeing with that, and stops a stray capital or a copy-paste space reading as a
+ * different user.
+ *
+ * Deliberately nothing cleverer. No dot-stripping, no plus-tag removal: those are
+ * provider-specific conventions, and collapsing `a+shop@gmail.com` into `a@gmail.com` would
+ * merge addresses the user considers distinct.
+ */
+export function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+/**
+ * A deliberately loose shape check — something before the @, something after, and a dot in
+ * the domain. Enough to catch a typo before spending a network round trip on it; the real
+ * arbiter is Firebase (and ultimately whether the verification email arrives).
+ */
+export function isPlausibleEmail(email: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalizeEmail(email));
+}

--- a/src/lib/password.ts
+++ b/src/lib/password.ts
@@ -1,0 +1,70 @@
+import { MIN_PASSWORD_LENGTH } from "@/lib/constants";
+
+/**
+ * Password feedback, deliberately kept to three states.
+ *
+ * The enforced policy is length only (`MIN_PASSWORD_LENGTH`). A four-bar meter scored on
+ * uppercase / digits / symbols implied those were required and quietly disagreed with what
+ * signup actually rejects — someone with a long, strong passphrase saw a mediocre score,
+ * while "Passw0rd!" looked excellent. These three states line up exactly with the rule:
+ *
+ * - `too-short`  — the only state that blocks submission
+ * - `acceptable` — meets the floor and will be accepted
+ * - `strong`     — comfortably beyond it
+ *
+ * "Strong" is earned by *length* first, because length is what actually resists guessing;
+ * character variety is a secondary route so a shorter mixed password isn't under-sold.
+ */
+export type PasswordStrength = "empty" | "too-short" | "acceptable" | "strong";
+
+/** Length at which a password counts as strong on length alone. */
+const STRONG_LENGTH = 12;
+
+/** Length at which a mixed-character password counts as strong. */
+const STRONG_MIXED_LENGTH = 10;
+
+export function countCharacterClasses(password: string): number {
+  let classes = 0;
+  if (/[a-z]/.test(password)) classes += 1;
+  if (/[A-Z]/.test(password)) classes += 1;
+  if (/[0-9]/.test(password)) classes += 1;
+  if (/[^A-Za-z0-9]/.test(password)) classes += 1;
+  return classes;
+}
+
+export function getPasswordStrength(password: string): PasswordStrength {
+  if (!password) return "empty";
+  if (password.length < MIN_PASSWORD_LENGTH) return "too-short";
+  if (password.length >= STRONG_LENGTH) return "strong";
+  if (password.length >= STRONG_MIXED_LENGTH && countCharacterClasses(password) >= 3) {
+    return "strong";
+  }
+  return "acceptable";
+}
+
+export const PASSWORD_STRENGTH_LABEL: Record<PasswordStrength, string> = {
+  empty: "",
+  "too-short": "Too short",
+  acceptable: "Acceptable",
+  strong: "Strong",
+};
+
+/**
+ * Brand-palette tints rather than a stock red/amber/green ramp. "Too short" is the warm
+ * terracotta already used for inline field errors; "strong" lands on the supporting
+ * emerald.
+ */
+export const PASSWORD_STRENGTH_COLOR: Record<PasswordStrength, string> = {
+  empty: "transparent",
+  "too-short": "#d97b6c",
+  acceptable: "#c9977a",
+  strong: "#5c7350",
+};
+
+/** How many of the three meter segments are lit. */
+export const PASSWORD_STRENGTH_SEGMENTS: Record<PasswordStrength, number> = {
+  empty: 0,
+  "too-short": 1,
+  acceptable: 2,
+  strong: 3,
+};

--- a/src/lib/provider-profile.ts
+++ b/src/lib/provider-profile.ts
@@ -1,0 +1,40 @@
+/**
+ * Reads a display name out of whatever shape an OAuth provider returned.
+ *
+ * The providers disagree. Google puts a flat `name` on the profile claims (plus
+ * `given_name` / `family_name`); Apple sends a nested `{ firstName, lastName }` object. The
+ * `fallback` is `result.user.displayName`, which the Firebase SDK sometimes populates for
+ * the session without writing it to the account record.
+ *
+ * Everything is defensive: these are third-party payloads whose shape we don't control, so
+ * a surprising type returns null rather than throwing into the sign-in path.
+ */
+export function readProviderName(
+  profile: unknown,
+  fallback?: string | null
+): string | null {
+  if (typeof fallback === "string" && fallback.trim()) return fallback.trim();
+  if (!profile || typeof profile !== "object") return null;
+
+  const claims = profile as Record<string, unknown>;
+
+  // Google: a ready-made full name.
+  if (typeof claims.name === "string" && claims.name.trim()) {
+    return claims.name.trim();
+  }
+
+  // Apple: { name: { firstName, lastName } }.
+  if (claims.name && typeof claims.name === "object") {
+    const { firstName, lastName } = claims.name as Record<string, unknown>;
+    const parts = [firstName, lastName].filter(
+      (part): part is string => typeof part === "string" && part.trim().length > 0
+    );
+    if (parts.length) return parts.map((part) => part.trim()).join(" ");
+  }
+
+  // Google's split claims, when `name` is absent.
+  const given = typeof claims.given_name === "string" ? claims.given_name.trim() : "";
+  const family = typeof claims.family_name === "string" ? claims.family_name.trim() : "";
+  const combined = `${given} ${family}`.trim();
+  return combined || null;
+}

--- a/src/lib/redirect.ts
+++ b/src/lib/redirect.ts
@@ -1,18 +1,272 @@
+import { REDIRECT_KEY } from "@/lib/constants";
+
 /**
- * Resolves a post-auth redirect target from a `from` value (query param or saved
- * destination). Shared by the login and verify-email flows so the open-redirect
- * guard lives in one place.
+ * The single place post-auth redirect destinations are validated, carried and stored.
  *
- * Accepts the legacy `"checkout"` token and same-origin absolute paths (which may
- * carry a query string, e.g. `/checkout?coupon=X`). Rejects protocol-relative
- * (`//evil.com`) and backslash (`/\`) forms, and anything else, falling back to
- * `/account`.
+ * `from` values are attacker-controlled (query string, and — via any XSS — sessionStorage),
+ * so this module is the *security boundary*: callers are never trusted to pre-validate.
+ * `resolveDestination` is total and non-throwing, and `withFrom` re-validates internally,
+ * so no unsafe value can reach `router.push` or be serialised into an auth URL.
+ *
+ * ## Destination precedence
+ *
+ *   Is `from` present on the URL?
+ *     ├─ Yes → validate it
+ *     │         ├─ valid   → use the validated destination
+ *     │         └─ invalid → DEFAULT_DESTINATION  (never falls back to sessionStorage)
+ *     └─ No  → read sessionStorage
+ *               ├─ valid and within TTL → use it
+ *               └─ invalid / expired / absent → DEFAULT_DESTINATION
+ *
+ * A present-but-invalid `from` deliberately short-circuits to `/account`. Letting it fall
+ * through to storage would let `?from=https://evil.example` interact with stale client
+ * state, which is exactly the surprise we don't want attacker input to be able to trigger.
+ *
+ * ## sessionStorage lifecycle (`REDIRECT_KEY`)
+ *
+ * - **Created** only by the social `handleSocial` paths, immediately before a provider call
+ *   that may become a full-page `signInWithRedirect`. The plain email/password path never
+ *   writes it — React state survives that flow, so there is nothing to recover.
+ * - **Read** only via `readDestination()`, which re-validates and drops entries older than
+ *   `DESTINATION_TTL_MS`. Consulted only when `from` is absent (see precedence above).
+ * - **Consumed** by `clearDestination()` on the successful post-auth navigation.
+ * - **Deleted** on consume, on social-auth failure, and on TTL expiry.
+ *
+ * The TTL plus clear-on-navigate is what stops an abandoned destination from hijacking an
+ * unrelated login later in the same tab session.
  */
-export function resolveDestination(from: string | null): string {
-  if (!from) return "/account";
-  if (from === "checkout") return "/checkout";
-  // Only allow same-origin absolute paths. Reject protocol-relative ("//evil.com")
-  // and any other value to avoid an open redirect.
-  if (from.startsWith("/") && !from.startsWith("//") && !from.startsWith("/\\")) return from;
-  return "/account";
+
+export const DEFAULT_DESTINATION = "/account";
+
+/** How long a stored social-redirect destination stays usable. */
+export const DESTINATION_TTL_MS = 10 * 60 * 1000;
+
+/**
+ * Base used only to parse candidate paths. `.invalid` is reserved by RFC 2606 and can
+ * never resolve, so a value that parses back to this origin is provably same-origin.
+ */
+const PARSE_BASE = "http://x.invalid";
+
+/** Routes that would bounce the user straight back into the auth flow. */
+const AUTH_ROUTES = ["/login", "/signup", "/forgot-password", "/verify-email"];
+
+/**
+ * Destinations that a *verified* email is a hard prerequisite for.
+ *
+ * The single source of truth for that policy. `/checkout` enforces it on itself
+ * (`CheckoutContent`), the post-auth navigation uses it to route unverified users through
+ * /verify-email first, and the verify page uses it to decide whether a manual "continue"
+ * would be a dead end. Previously the same rule was spelled out separately in each place.
+ *
+ * `/account` is deliberately absent: it stays reachable while unverified and shows an
+ * advisory reminder instead. Adding it here would turn that reminder into a gate.
+ */
+const VERIFICATION_REQUIRED_ROUTES = ["/checkout"];
+
+/**
+ * True for any C0 control character or DEL. Browsers strip tabs and newlines from URLs
+ * *after* our checks would run, so a tab in `/<tab>/evil.com` would otherwise leave us
+ * approving what the browser then treats as `//evil.com`.
+ */
+function hasControlChar(value: string): boolean {
+  for (let i = 0; i < value.length; i += 1) {
+    const code = value.charCodeAt(i);
+    if (code <= 0x1f || code === 0x7f) return true;
+  }
+  return false;
+}
+
+/** `decodeURIComponent` throws on malformed percent-encoding (`%zz`, a trailing `%`). */
+function safeDecode(value: string): string | null {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Rejects the forms that browsers normalise into an off-site jump. Applied to both the raw
+ * input and the decoded path — a backslash or control character is dangerous either way.
+ */
+function hasEscapeForm(value: string): boolean {
+  return value.startsWith("//") || value.includes("\\") || hasControlChar(value);
+}
+
+/**
+ * Resolves a `from` value (query param or stored destination) to a safe internal path.
+ *
+ * Total and non-throwing: every input — malformed percent-encoding, arbitrary Unicode,
+ * control characters, encoded backslashes, protocol-relative and external URLs — returns
+ * either a validated same-origin path or `DEFAULT_DESTINATION`. Query strings and
+ * fragments on an accepted path are preserved (e.g. `/checkout?coupon=X`).
+ */
+export function resolveDestination(from: string | null | undefined): string {
+  if (typeof from !== "string") return DEFAULT_DESTINATION;
+
+  const raw = from.trim();
+  if (!raw) return DEFAULT_DESTINATION;
+
+  // Legacy bare token. No producer emits this any more, but old links may carry it.
+  if (raw === "checkout") return "/checkout";
+
+  // The raw value additionally rejects *any* whitespace. A genuine URL percent-encodes
+  // spaces, so a literal one means the value was hand-crafted. (Encoded whitespace inside
+  // a path — `/store/a%20b` — stays legal; it can't act as a delimiter.)
+  if (!raw.startsWith("/") || hasEscapeForm(raw) || /\s/.test(raw)) return DEFAULT_DESTINATION;
+
+  // The WHATWG parser normalises backslashes to slashes and strips tabs/newlines, so an
+  // origin check here catches anything that slipped past the literal checks above.
+  let url: URL;
+  try {
+    url = new URL(raw, PARSE_BASE);
+  } catch {
+    return DEFAULT_DESTINATION;
+  }
+  if (url.origin !== PARSE_BASE) return DEFAULT_DESTINATION;
+
+  // Re-check the decoded path: `/%5C%5Cevil.com` and `/%09//evil.com` are only dangerous
+  // once decoded, and a decode failure means the value was malformed to begin with.
+  const decoded = safeDecode(url.pathname);
+  if (decoded === null || hasEscapeForm(decoded)) return DEFAULT_DESTINATION;
+
+  // Sending the user back into the auth flow would loop them.
+  const path = url.pathname;
+  if (AUTH_ROUTES.some((route) => path === route || path.startsWith(`${route}/`)))
+    return DEFAULT_DESTINATION;
+
+  return url.pathname + url.search + url.hash;
+}
+
+/**
+ * Builds an auth URL carrying a validated `?from=` destination.
+ *
+ * Validation happens *here* rather than at the call site, so an unsafe value can never be
+ * serialised into the parameter: `withFrom("/signup", "https://evil.example")` yields
+ * `/signup?from=%2Faccount`. Passing nothing returns `base` unchanged.
+ */
+export function withFrom(base: string, dest: string | null | undefined): string {
+  if (dest === null || dest === undefined || dest === "") return base;
+  const separator = base.includes("?") ? "&" : "?";
+  return `${base}${separator}from=${encodeURIComponent(resolveDestination(dest))}`;
+}
+
+/**
+ * Marks a /login URL as "you were signed in a moment ago and no longer are", so the sign-in
+ * page can say so instead of leaving the user to wonder why they were thrown out.
+ */
+export const SESSION_EXPIRED_PARAM = "session";
+
+/**
+ * The /login URL a protected page should send someone to when Firebase reports no user
+ * despite the routing hint letting them in — an expired session, a revoked token, or a hint
+ * that was never backed by one. The destination rides along so signing back in returns them
+ * to where they were headed.
+ */
+export function sessionExpiredLoginUrl(dest: string | null | undefined): string {
+  const base = withFrom("/login", dest);
+  const separator = base.includes("?") ? "&" : "?";
+  return `${base}${separator}${SESSION_EXPIRED_PARAM}=expired`;
+}
+
+/**
+ * Whether reaching this destination requires a verified email. Accepts a full destination,
+ * so the query string and hash are ignored (`/checkout?coupon=X` still counts).
+ */
+export function requiresVerification(destination: string): boolean {
+  const path = resolveDestination(destination).split(/[?#]/)[0];
+  return VERIFICATION_REQUIRED_ROUTES.some(
+    (route) => path === route || path.startsWith(`${route}/`)
+  );
+}
+
+/**
+ * Where to send someone the moment they finish authenticating.
+ *
+ * Normally straight to the destination they asked for. The exception is an unverified user
+ * heading somewhere that requires verification: sending them to the destination would just
+ * have that page bounce them to /verify-email, costing a history entry and a flash of a
+ * loading screen. Routing them there directly is the same outcome without the detour, and
+ * `from` keeps the original destination so verifying lands them where they meant to go.
+ *
+ * Destinations that don't require verification — `/account` above all — are unaffected:
+ * an unverified user still reaches them and sees the advisory reminder.
+ */
+export function postAuthDestination(
+  destination: string,
+  emailVerified: boolean
+): string {
+  // Resolve on both branches. Callers happen to pass an already-resolved destination
+  // today, but this returns a value that goes straight into router.push — it validates
+  // its own input rather than trusting that, same as withFrom.
+  const safe = resolveDestination(destination);
+  return !emailVerified && requiresVerification(safe)
+    ? withFrom("/verify-email", safe)
+    : safe;
+}
+
+/**
+ * Stores a destination across a full-page `signInWithRedirect`. Validated on the way in and
+ * again on the way out, and stamped so `readDestination` can expire it.
+ */
+export function saveDestination(dest: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    const entry = JSON.stringify({ d: resolveDestination(dest), t: Date.now() });
+    sessionStorage.setItem(REDIRECT_KEY, entry);
+  } catch {
+    // Storage disabled or full (e.g. Safari private mode) — the flow still works, the
+    // user just lands on the default destination.
+  }
+}
+
+/**
+ * Reads the stored destination, or null when there is nothing usable. Non-destructive —
+ * `clearDestination()` is what consumes it. A malformed, mis-shaped or expired entry is
+ * treated as absent and cleared.
+ */
+export function readDestination(): string | null {
+  if (typeof window === "undefined") return null;
+
+  let stored: string | null;
+  try {
+    stored = sessionStorage.getItem(REDIRECT_KEY);
+  } catch {
+    return null;
+  }
+  if (!stored) return null;
+
+  let entry: unknown;
+  try {
+    entry = JSON.parse(stored);
+  } catch {
+    clearDestination();
+    return null;
+  }
+
+  if (typeof entry !== "object" || entry === null) {
+    clearDestination();
+    return null;
+  }
+  const { d, t } = entry as { d?: unknown; t?: unknown };
+  if (typeof d !== "string" || typeof t !== "number" || !Number.isFinite(t)) {
+    clearDestination();
+    return null;
+  }
+  if (Date.now() - t > DESTINATION_TTL_MS) {
+    clearDestination();
+    return null;
+  }
+
+  return resolveDestination(d);
+}
+
+/** Consumes the stored destination. Safe to call when nothing is stored. */
+export function clearDestination(): void {
+  if (typeof window === "undefined") return;
+  try {
+    sessionStorage.removeItem(REDIRECT_KEY);
+  } catch {
+    // Nothing to do — a destination we can't clear will expire on its own.
+  }
 }

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,0 +1,102 @@
+import {
+  CART_STORAGE_KEY,
+  LEGACY_SESSION_HINT_COOKIE,
+  REDIRECT_KEY,
+  SESSION_HINT_COOKIE,
+  WISHLIST_STORAGE_KEY,
+} from "@/lib/constants";
+
+/**
+ * Owns the presence hint cookie and the local traces of a signed-in session.
+ *
+ * The hint exists for one reason: the edge proxy runs before any Firebase SDK and needs
+ * *some* signal to decide whether to render a protected route or bounce to /login. It is a
+ * routing convenience, nothing more — see the contract on `SESSION_HINT_COOKIE`. Anything
+ * that actually matters re-checks `onAuthStateChanged` once Firebase has loaded, and clears
+ * a hint that turns out to be lying.
+ *
+ * ## Lifetime
+ *
+ * The hint is written to match Firebase's own persistence choice, so the two can't drift:
+ *
+ * - "Remember me" on  → `browserLocalPersistence` → 30-day cookie.
+ * - "Remember me" off → `browserSessionPersistence` → **session** cookie (no `max-age`),
+ *   so it dies when the browser closes, exactly as the Firebase session does.
+ *
+ * The choice is mirrored in `sessionStorage` because that storage has precisely the
+ * lifetime we need to mirror: it survives reloads within the browsing session and is gone
+ * once the browser closes, which is the same boundary `browserSessionPersistence` uses.
+ * Without it, a reload would re-stamp a 30-day cookie over a session-only login and leave a
+ * stale hint behind for a month.
+ */
+
+const SESSION_ONLY_KEY = "hb-session-only";
+const PERSISTENT_MAX_AGE_SECONDS = 60 * 60 * 24 * 30;
+
+function cookieSuffix(): string {
+  return location.protocol === "https:" ? "; Secure" : "";
+}
+
+/** True when this login opted out of "remember me" and must not outlive the browser. */
+export function isSessionOnly(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return sessionStorage.getItem(SESSION_ONLY_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+/** Records the "remember me" choice so a later reload writes the matching cookie. */
+export function markSessionOnly(sessionOnly: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    if (sessionOnly) sessionStorage.setItem(SESSION_ONLY_KEY, "1");
+    else sessionStorage.removeItem(SESSION_ONLY_KEY);
+  } catch {
+    // Storage unavailable — fall back to a persistent hint, which the client-side guards
+    // will invalidate anyway once Firebase reports no user.
+  }
+}
+
+/** Writes the presence hint, matched to the persistence the session was created with. */
+export function setSessionHint(): void {
+  if (typeof document === "undefined") return;
+  const age = isSessionOnly() ? "" : `; max-age=${PERSISTENT_MAX_AGE_SECONDS}`;
+  document.cookie = `${SESSION_HINT_COOKIE}=1; path=/${age}; SameSite=Lax${cookieSuffix()}`;
+}
+
+/** Removes the presence hint, including any cookie left over from the previous name. */
+export function clearSessionHint(): void {
+  if (typeof document === "undefined") return;
+  const suffix = cookieSuffix();
+  for (const name of [SESSION_HINT_COOKIE, LEGACY_SESSION_HINT_COOKIE]) {
+    document.cookie = `${name}=; path=/; max-age=0; SameSite=Lax${suffix}`;
+  }
+}
+
+/**
+ * Wipes the local traces of a session on explicit sign-out: the hint, the "remember me"
+ * marker, the pending redirect destination, and the cart/wishlist.
+ *
+ * Cart and wishlist are cleared because they persist to `localStorage` under fixed keys
+ * with no user scoping, so on a shared device the next person would otherwise open the bag
+ * and find the previous user's items. Clearing storage here closes the durable leak; the
+ * in-memory React state is reset by the sign-out call sites, which own those contexts
+ * (`AuthProvider` sits above them and can't reach their hooks).
+ *
+ * Deliberately *not* called on session expiry — losing a bag because a token lapsed would
+ * be a nasty surprise. Only an explicit sign-out clears shopping state.
+ */
+export function clearLocalUserState(): void {
+  clearSessionHint();
+  if (typeof window === "undefined") return;
+  try {
+    sessionStorage.removeItem(SESSION_ONLY_KEY);
+    sessionStorage.removeItem(REDIRECT_KEY);
+    localStorage.removeItem(CART_STORAGE_KEY);
+    localStorage.removeItem(WISHLIST_STORAGE_KEY);
+  } catch {
+    // Storage unavailable — nothing durable was written either.
+  }
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
-import { AUTH_COOKIE } from "@/lib/constants";
+import { LEGACY_SESSION_HINT_COOKIE, SESSION_HINT_COOKIE } from "@/lib/constants";
+import { resolveDestination } from "@/lib/redirect";
 
 // Routes that require a session.
 const PROTECTED = ["/account", "/checkout"];
@@ -41,7 +42,15 @@ function buildCsp(nonce: string): string {
 }
 
 export function proxy(request: NextRequest) {
-  const hasAuth = Boolean(request.cookies.get(AUTH_COOKIE));
+  // A *hint*, never proof. It says "a session may exist", which is enough to decide which
+  // page to render without a Firebase round trip at the edge. Every protected page
+  // re-checks the real Firebase session on the client and bounces if the hint was lying.
+  // The legacy name is still read so browsers holding a pre-rename cookie don't get an
+  // extra redirect; it can be dropped once those have expired.
+  const hasSessionHint = Boolean(
+    request.cookies.get(SESSION_HINT_COOKIE) ??
+      request.cookies.get(LEGACY_SESSION_HINT_COOKIE)
+  );
   const { pathname } = request.nextUrl;
 
   const nonce = crypto.randomUUID();
@@ -65,15 +74,28 @@ export function proxy(request: NextRequest) {
   };
 
   // Gate protected routes behind a session.
-  if (isProtected && !hasAuth) {
-    const url = request.nextUrl.clone();
-    url.pathname = "/login";
-    url.searchParams.set("from", pathname);
+  if (isProtected && !hasSessionHint) {
+    // A fresh URL rather than a clone of nextUrl: cloning drags the protected page's own
+    // query params onto the login screen. `from` carries path *and* search so
+    // /checkout?coupon=X round-trips; resolveDestination validates it (same guard the
+    // client uses) and searchParams does the encoding.
+    const url = new URL("/login", request.url);
+    url.searchParams.set(
+      "from",
+      resolveDestination(pathname + request.nextUrl.search)
+    );
     return withCsp(NextResponse.redirect(url));
   }
 
-  // Keep signed-in users out of the auth screens.
-  if (isAuthPage && hasAuth) {
+  // Keep signed-in users out of the auth screens — but never when the URL carries `from`.
+  //
+  // `from` means something deliberately routed the visitor here, which includes a client
+  // guard that just found the hint was lying. If we bounced those back, a hint the client
+  // cannot clear (one scoped to another path, or a browser refusing the write) would ping
+  // the user between /account and /login forever. Honouring `from` breaks that loop, and
+  // costs nothing for a genuinely signed-in visitor: LoginContent sees `user` immediately
+  // and forwards them to the destination they asked for.
+  if (isAuthPage && hasSessionHint && !request.nextUrl.searchParams.has("from")) {
     return withCsp(NextResponse.redirect(new URL("/account", request.url)));
   }
 


### PR DESCRIPTION
Closes #75

Ten-phase hardening pass over the Firebase auth flow, reviewed phase by phase.

**Preserved deliberately:** Firebase Auth stays the provider, the popup → redirect social
fallback is unchanged, `/account` remains reachable while unverified, and the checkout
verification requirement is untouched.

## The four bugs that were live

1. **Open redirect.** The guard only blocked the literal prefixes `//` and `/\`, so
   `/%09//evil.com` and `/%5C%5Cevil.com` passed — browsers normalise tabs and backslashes
   *after* our check ran. Separately, the `sessionStorage` fallback reached `router.push`
   with no validation at all.
2. **Signup reported failure for accounts that existed.** `updateProfile` sat unguarded
   between account creation and the guarded verification send. If it threw, the user was
   told signup failed and retried straight into `auth/email-already-in-use`.
3. **Account enumeration on two forms.** "No account found with this email" and "Incorrect
   password" let anyone test an address for membership — on the sign-in form as well as
   password reset.
4. **Raw internal errors rendered to users.** `getAuthErrorMessage` fell back to
   `err.message`, so a stray `TypeError` from our own code would surface verbatim.

## Structural changes

| Area | Change |
| --- | --- |
| Redirects | `src/lib/redirect.ts` rewritten as a total, non-throwing boundary. `withFrom` validates its own input, so caller discipline can't leak an unsafe destination. |
| Precedence | One documented rule: a present-but-invalid `from` resolves to `/account` and **never** falls through to stored state. |
| Session hint | `AUTH_COOKIE` → `SESSION_HINT_COOKIE`, documented as routing-only. Lifetime now matches Firebase persistence, so "remember me" off no longer leaves a 30-day stale hint. |
| Redirect loop | The proxy no longer bounces auth pages carrying `?from=` — a hint the client can't clear used to ping the user between `/account` and `/login` forever. |
| Sign-out | Clears cart and wishlist storage; they previously survived on shared devices. Session *expiry* deliberately does not. |
| Errors | All Firebase error interpretation in `src/lib/auth-errors.ts`, duck-typed rather than `instanceof` so it survives duplicate SDK copies in a bundle. |

## Verification

- **275 assertions** run against the real modules via Node type-stripping — hostile redirect
  inputs, the enumeration-safe message trio reducing to a set of size 1, provider name shapes
  for Google *and* Apple, password strength, session-expiry URL building.
- Browser-verified without credentials: proxy redirect fidelity, stale-hint clearing with no
  loop, malformed `%zz` / `%E0%A4%A` on all four auth routes with zero console errors,
  invalid `from` not consuming stored state, client-side validation making **zero**
  `identitytoolkit` requests, neutral reset confirmation for an unregistered address, and the
  password meter's computed colours.
- `npm run build` passes, TypeScript clean.

**`npm run lint` still fails on two pre-existing `react-hooks/rules-of-hooks` errors in
`src/lib/shopify.ts`** (`usePlaceholderCatalogue`). Confirmed present on `main` by stashing
this branch's changes — not introduced here, but it means lint is currently useless as a gate
(relates to #52 / #59).

## Not verified — needs real accounts

Anything requiring a signed-in, unverified, or social account: the verification polling and
resend, signup partial-failure recovery, credential conflicts, Apple's name capture, and the
`/account` reminder card. The logic behind these is covered by the assertions above; the
Firebase integration around them is not. A manual checklist is in the phase reports.

## Scope notes

- **Phase 10 is assessment only** — `docs/auth-account-management.md` documents provider
  linking/unlinking, required Firebase APIs, recent-login handling and edge cases. Nothing
  was built, because there is no Account Settings screen to build it into (the `/account`
  cards are still stubs).
- Three error codes for provider linking are mapped with no callers yet, flagged in-file.
  Easy to drop if you'd rather keep the map to what can currently fire.
- **Server-side `emailVerified` enforcement is still open as #57.** There are no server-side
  user operations yet — checkout is a placeholder — so client-side gating is currently the
  entire model. This becomes load-bearing the moment payments land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FqMNJw3rzcQr6FJFa4Udmv
