### PR TITLE
feat: expose the Shopify variant id on the cart line (#92)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,10 @@ For non-feature work substitute the type segment: `fix`, `chore`, `refactor`, `d
 ## Conventions
 
 - **Cart/wishlist item ids are namespaced strings** — `product:<n>` (the numeric half of the
-  Shopify product gid) and `bundle:<slug>` (e.g. `bundle:glow`). Never bare numbers.
+  Shopify product gid). Never bare numbers. **Bundles no longer enter the cart** (#92): with no
+  Shopify variant they have no `merchandiseId` and could never be checked out, so `BundleCard`
+  links to the catalogue instead of adding to the bag. `bundle:<slug>` is therefore no longer a
+  cart key — restoring one depends on modelling bundles as Shopify products (#65).
   **The cart owns the variant suffix; the wishlist does not** (#63): cart lines append the
   Shopify variant id (`product:1#4567`) so two sizes are distinct rows, while a wishlist entry
   is a *product* and stays `product:1` — `isWishlisted(product.id)` is what fills the heart.
@@ -128,6 +131,13 @@ For non-feature work substitute the type segment: `fix`, `chore`, `refactor`, `d
   the variant list isn't stored.
   Build every cart id with `toCartItem()` from `src/lib/product.ts` — it is the only place one
   is constructed. See `CartContext`.
+  **A cart line also carries `variantId`** (#92) — the same numeric variant id the `#` suffix
+  encodes, exposed as a field so the checkout handoff never splits the key apart. It is
+  `string | null` and **required**, so the compiler names every producer; `null` means the line
+  has no Shopify variant and cannot be bought, which #31 must reject rather than assume. Store
+  the numeric id, not a gid — `gid://shopify/ProductVariant/<id>` is rebuilt at mutation time.
+  Cart entries persisted before the field existed are dropped on restore, same reasoning as
+  `cartLine` above.
 - **Catalog data** (#4): products are fetched in `src/lib/shopify.ts` — `getProducts`,
   `getFeaturedProducts`, `getProductBySlug`; the `defaultVariant` / `isSoldOut` /
   `toCartItem` helpers live alongside the types in `src/lib/product.ts`. Fetches are tagged
@@ -135,7 +145,8 @@ For non-feature work substitute the type segment: `fix`, `chore`, `refactor`, `d
   the tag on demand via `POST /api/revalidate`.
   With no credentials the store degrades to non-purchasable "Coming Soon" placeholders;
   a *configured* store that errors renders an empty grid rather than fake products.
-  Bundles are still hardcoded in `src/lib/products.ts` — no Shopify equivalent yet.
+  Bundles are still hardcoded in `src/lib/products.ts` — no Shopify equivalent yet, and
+  display-only since #92.
 - **Webhook auth** (#4): `/api/revalidate` verifies Shopify's `X-Shopify-Hmac-Sha256`
   (base64 HMAC-SHA256 over the raw body) with `timingSafeEqual`. Needs
   `SHOPIFY_WEBHOOK_SECRET` — the value Shopify shows under Settings → Notifications →

--- a/src/app/store/StoreContent.tsx
+++ b/src/app/store/StoreContent.tsx
@@ -63,6 +63,20 @@ export default function StoreContent({ products }: { products: ShopifyProduct[] 
 
   const clearCategory = useCallback(() => setActiveCategory(ALL_CATEGORIES), []);
 
+  /**
+   * On this page "Shop Bundle" would otherwise link to `/store` — the page the
+   * shopper is already on. Send them to the collection instead, reusing the same
+   * measured scroll `StoreHero` uses. The card keeps `#collection` as its href so
+   * the control still works without JS.
+   */
+  const handleBundleShop = useCallback(
+    (e: React.MouseEvent<HTMLAnchorElement>) => {
+      e.preventDefault();
+      scrollToCollection();
+    },
+    [scrollToCollection]
+  );
+
   return (
     <>
       <StoreHero onShopClick={scrollToCollection} />
@@ -117,7 +131,14 @@ export default function StoreContent({ products }: { products: ShopifyProduct[] 
 
           <div className="grid md:grid-cols-2 gap-6 lg:gap-8">
             {bundles.map((bundle, index) => (
-              <BundleCard key={bundle.id} bundle={bundle} index={index} isInView={bundlesInView} />
+              <BundleCard
+                key={bundle.id}
+                bundle={bundle}
+                index={index}
+                isInView={bundlesInView}
+                href={`#${COLLECTION_ID}`}
+                onShopClick={handleBundleShop}
+              />
             ))}
           </div>
         </div>

--- a/src/components/BundleCard.tsx
+++ b/src/components/BundleCard.tsx
@@ -11,10 +11,26 @@ export default function BundleCard({
   bundle,
   index,
   isInView,
+  href,
+  onShopClick,
 }: {
   bundle: Bundle;
   index: number;
   isInView: boolean;
+  /**
+   * Where "Shop Bundle" sends the shopper. The card renders on two pages, so the
+   * destination can't be hardcoded: from the home page it's `/store`, but on
+   * `/store` itself that would be a self-link — a control that promises
+   * something and does nothing.
+   */
+  href: string;
+  /**
+   * Optional same-page handler. `/store` passes one that scrolls to the
+   * collection instead of navigating, matching `StoreHero`'s `onShopClick`; the
+   * codebase measures the navbar rather than using `scroll-margin-top`, so a bare
+   * anchor jump would land under it. `href` stays the no-JS fallback.
+   */
+  onShopClick?: (e: React.MouseEvent<HTMLAnchorElement>) => void;
 }) {
   // No add-to-bag: a bundle has no Shopify variant, so it could never produce a
   // `merchandiseId` for the checkout handoff (#92). It used to build a
@@ -95,7 +111,8 @@ export default function BundleCard({
 
               <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.97 }}>
                 <Link
-                  href="/store"
+                  href={href}
+                  onClick={onShopClick}
                   aria-label={`Shop the ${bundle.name} in the store`}
                   className="flex items-center gap-2 px-5 py-2.5 rounded-full text-white text-[10px] font-semibold tracking-wide uppercase transition-all"
                   style={{

--- a/src/components/BundleCard.tsx
+++ b/src/components/BundleCard.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import Image from "next/image";
+import Link from "next/link";
 import { motion } from "framer-motion";
 import { ArrowRight, Sparkles } from "lucide-react";
-import { useCart } from "@/context/CartContext";
 import { formatPrice } from "@/lib/format";
 import type { Bundle } from "@/lib/products";
 
@@ -16,18 +16,12 @@ export default function BundleCard({
   index: number;
   isInView: boolean;
 }) {
-  const { addItem } = useCart();
-
-  const handleAddBundle = () => {
-    addItem({
-      id: `bundle:${bundle.id}`,
-      name: bundle.name,
-      category: "Bundle",
-      price: bundle.price,
-      image: bundle.products[0],
-    });
-  };
-
+  // No add-to-bag: a bundle has no Shopify variant, so it could never produce a
+  // `merchandiseId` for the checkout handoff (#92). It used to build a
+  // `bundle:<slug>` line by hand — the one cart id in the codebase that bypassed
+  // toCartItem() — which meant a shopper could fill a bag with something the
+  // store cannot sell. The card now sends them to the catalogue instead. Restore
+  // a real purchase path once bundles are modelled as Shopify products (#65).
   return (
     <motion.div
       initial={{ opacity: 0, y: 40 }}
@@ -99,19 +93,20 @@ export default function BundleCard({
                 </span>
               </div>
 
-              <motion.button
-                whileHover={{ scale: 1.05 }}
-                whileTap={{ scale: 0.97 }}
-                onClick={handleAddBundle}
-                className="flex items-center gap-2 px-5 py-2.5 rounded-full text-white text-[10px] font-semibold tracking-wide uppercase transition-all"
-                style={{
-                  background: bundle.accentColor,
-                  boxShadow: `0 4px 20px ${bundle.accentColor}45`,
-                }}
-              >
-                Shop Bundle
-                <ArrowRight size={12} />
-              </motion.button>
+              <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.97 }}>
+                <Link
+                  href="/store"
+                  aria-label={`Shop the ${bundle.name} in the store`}
+                  className="flex items-center gap-2 px-5 py-2.5 rounded-full text-white text-[10px] font-semibold tracking-wide uppercase transition-all"
+                  style={{
+                    background: bundle.accentColor,
+                    boxShadow: `0 4px 20px ${bundle.accentColor}45`,
+                  }}
+                >
+                  Shop Bundle
+                  <ArrowRight size={12} />
+                </Link>
+              </motion.div>
             </div>
           </div>
         </div>

--- a/src/components/WishlistSidebar.tsx
+++ b/src/components/WishlistSidebar.tsx
@@ -8,6 +8,7 @@ import { useCart } from "@/context/CartContext";
 import SideDrawer from "@/components/SideDrawer";
 import { ease } from "@/lib/motion";
 import { formatPrice } from "@/lib/format";
+import type { CartLine } from "@/lib/product";
 
 
 export default function WishlistSidebar() {
@@ -31,10 +32,12 @@ export default function WishlistSidebar() {
   // isn't the min-price variant.
   //
   // Entries restored without a cartLine are dropped in WishlistContext, so the
-  // fallback here is a type-level total rather than a live path.
-  const toBagLine = (item: WishlistProduct) => {
+  // fallback here is a type-level total rather than a live path. Its `variantId:
+  // null` says the same thing structurally: a line with no captured variant has
+  // nothing to buy, and #31 rejects it rather than guessing a variant.
+  const toBagLine = (item: WishlistProduct): CartLine => {
     const { cartLine, ...product } = item;
-    return cartLine ?? product;
+    return cartLine ?? { ...product, variantId: null };
   };
 
   // Move every saved item into the bag (and out of the wishlist), then hand

--- a/src/components/sections/Bundles.tsx
+++ b/src/components/sections/Bundles.tsx
@@ -58,7 +58,13 @@ export default function Bundles() {
         {/* Bundles grid */}
         <div className="grid md:grid-cols-2 gap-6 lg:gap-8">
           {bundles.map((bundle, index) => (
-            <BundleCard key={bundle.id} bundle={bundle} index={index} isInView={isInView} />
+            <BundleCard
+              key={bundle.id}
+              bundle={bundle}
+              index={index}
+              isInView={isInView}
+              href="/store"
+            />
           ))}
         </div>
       </div>

--- a/src/context/CartContext.tsx
+++ b/src/context/CartContext.tsx
@@ -13,8 +13,19 @@ import {
 import { CART_STORAGE_KEY as STORAGE_KEY } from "@/lib/constants";
 
 export interface CartProduct {
-  /** Namespaced key, e.g. "product:1" or "bundle:glow" — never a bare number. */
+  /**
+   * Namespaced key, e.g. "product:1" — never a bare number. Variant-specific
+   * lines append `#<variantId>` so two sizes are distinct rows. Bundles no
+   * longer enter the bag (#92): they have no Shopify variant, so they could
+   * never be checked out.
+   */
   id: string;
+  /**
+   * Numeric Shopify variant id, mirroring `CartLine.variantId` (#92). `null`
+   * means the line cannot be purchased. See the restore filter below for how
+   * entries persisted before this field are handled.
+   */
+  variantId: string | null;
   name: string;
   category: string;
   price: number;
@@ -57,7 +68,16 @@ export function CartProvider({ children }: { children: ReactNode }) {
         if (Array.isArray(parsed)) {
           // Drop legacy entries with numeric ids (pre-#20): they no longer map to
           // any product and could collide with the new namespaced keys.
-          const restored = parsed.filter((p) => typeof p.id === "string");
+          //
+          // Also drop anything saved before `variantId` existed (#92), mirroring
+          // what the wishlist does for `cartLine`. A stored line cannot be
+          // repaired — the variant list isn't in it — so falling back would put
+          // an unbuyable line in front of the checkout handoff. Two things make
+          // dropping safe: `clearLocalUserState()` already wipes this key on
+          // sign-out, and nothing is in production yet, so no real bag is lost.
+          const restored = parsed.filter(
+            (p) => typeof p.id === "string" && p.variantId !== undefined
+          );
           // One-time hydrate from localStorage on mount; can't read storage
           // during SSR/render without a hydration mismatch, so restore here.
           // eslint-disable-next-line react-hooks/set-state-in-effect

--- a/src/context/CartContext.tsx
+++ b/src/context/CartContext.tsx
@@ -75,8 +75,13 @@ export function CartProvider({ children }: { children: ReactNode }) {
           // an unbuyable line in front of the checkout handoff. Two things make
           // dropping safe: `clearLocalUserState()` already wipes this key on
           // sign-out, and nothing is in production yet, so no real bag is lost.
+          // Positive check rather than `!== undefined`: the parsed value is
+          // untrusted JSON, so anything that isn't a well-formed variantId —
+          // absent, or a number from a hand-edited store — is treated as legacy.
           const restored = parsed.filter(
-            (p) => typeof p.id === "string" && p.variantId !== undefined
+            (p) =>
+              typeof p.id === "string" &&
+              (typeof p.variantId === "string" || p.variantId === null)
           );
           // One-time hydrate from localStorage on mount; can't read storage
           // during SSR/render without a hydration mismatch, so restore here.

--- a/src/context/WishlistContext.tsx
+++ b/src/context/WishlistContext.tsx
@@ -81,8 +81,19 @@ export function WishlistProvider({ children }: { children: ReactNode }) {
         // line), so `cartLine == null` identifies legacy entries exactly.
         // Bundles never enter the wishlist — BundleCard has no wishlist control —
         // so nothing legitimate is caught by this.
+        //
+        // The same reasoning extends to a cartLine captured before `variantId`
+        // existed (#92). That is a *stale-shaped* line rather than a missing one,
+        // so `cartLine != null` lets it through and `toBagLine` hands it to the
+        // bag verbatim — putting a line with `variantId: undefined` in the cart,
+        // which JSON.stringify then omits entirely, so the cart's own restore
+        // filter silently discards the row on the next load. Probe the captured
+        // line's field, not merely the line's presence.
         const restored = (JSON.parse(raw) as WishlistProduct[]).filter(
-          (p) => typeof p.id === "string" && p.cartLine != null
+          (p) =>
+            typeof p.id === "string" &&
+            p.cartLine != null &&
+            p.cartLine.variantId !== undefined
         );
         // One-time hydrate from localStorage on mount; can't read storage
         // during SSR/render without a hydration mismatch, so restore here.

--- a/src/lib/product.ts
+++ b/src/lib/product.ts
@@ -123,6 +123,19 @@ export function isSoldOut(product: ShopifyProduct): boolean {
  */
 export interface CartLine {
   id: string;
+  /**
+   * Numeric Shopify variant id — the same value the `#<variantId>` half of `id`
+   * already carries, exposed as a field so nothing has to split the key back
+   * apart to reach it (#92). Numeric, not a gid: `shopify.ts` stores the trailing
+   * segment, and the checkout handoff rebuilds
+   * `gid://shopify/ProductVariant/<id>` at mutation time.
+   *
+   * `null` means the line has no Shopify variant and therefore cannot be bought.
+   * Required rather than optional — unlike `WishlistProduct.cartLine?`, whose
+   * optionality exists purely for the persisted shape — so the compiler
+   * enumerates every producer. #31 must reject `null` rather than assume.
+   */
+  variantId: string | null;
   name: string;
   category: string;
   price: number;
@@ -146,6 +159,11 @@ export function toCartItem(
 
   return {
     id: v ? `${product.id}#${v.id}` : product.id,
+    // Defensive rather than load-bearing: `v` is only undefined for a product
+    // with no variants, which today means the unconfigured-store "Coming Soon"
+    // tiles — and those already have every purchase control stripped, so they
+    // never reach the bag. TypeScript can't prove that, and #31 shouldn't trust it.
+    variantId: v?.id ?? null,
     name: hasChoice && v ? `${product.name} — ${v.label}` : product.name,
     category: product.category,
     price: v?.price ?? product.price,

--- a/src/lib/products.ts
+++ b/src/lib/products.ts
@@ -2,9 +2,14 @@
 // are a merchandising construct with no Shopify equivalent yet, so they remain
 // placeholder content until they're modelled as Shopify products or a
 // collection.
+//
+// DISPLAY ONLY. Bundles no longer enter the cart (#92) — with no Shopify variant
+// they have no `merchandiseId`, so a bundle line could never be checked out.
+// BundleCard links to the catalogue instead of adding to the bag. Modelling them
+// as real Shopify products (#65) is what restores a purchase path.
 
 export interface Bundle {
-  /** Bundle slug; cart key is built as `bundle:${id}`. */
+  /** Bundle slug. Used for React keys and copy — no longer a cart key (#92). */
   id: string;
   name: string;
   tagline: string;


### PR DESCRIPTION
Closes #92. Prerequisite for #31 (hosted checkout handoff); completes the last box on #4.

## Why

`cartCreate` needs `merchandiseId: "gid://shopify/ProductVariant/<id>"` per line. That id was
**already in the cart** — `toCartItem()` encodes it into the key as `product:1#42` — but only
*recoverably*, not *addressably*. Reaching it meant splitting a composite key at the point of
purchase, putting knowledge of the key format in a second place. Nothing in the codebase parses a
cart id apart today, and #31 shouldn't be the first thing to.

## What changed

**`variantId: string | null`, required on both `CartLine` and `CartProduct`** (they aren't linked
by a type alias). Required rather than optional is the point of the change — the compiler then
names every producer. It found exactly two, and both needed to change anyway:

- **`BundleCard`** — the one `addItem` call site that bypassed `toCartItem()`, building
  `bundle:<slug>` from an inline literal.
- **`WishlistSidebar.toBagLine`** — the `cartLine ?? product` fallback, already unreachable at
  runtime because `WishlistContext` drops entries without a `cartLine` (#63).

Numeric id, not a gid: nothing else in the client model holds one, and #31 rebuilds it at
mutation time.

**Bundles no longer enter the bag.** Hardcoded with no Shopify equivalent (#65), so a bundle line
could never produce a `merchandiseId` — today a shopper can fill a bag with something the store
cannot sell. The card now links to the catalogue. A real purchase path returns with #65.

**Legacy cart entries are dropped on restore**, mirroring the wishlist's `cartLine` handling
(#63): a stored line can't be repaired because the variant list isn't in it. Safe here because
`clearLocalUserState()` already wipes the key on sign-out and nothing is in production yet.

## Deliberately not in scope

**Stock is untouched — a sold-out variant still produces a line.** That guard belongs to #91,
which says it needs a UX decision (and possibly a refetch) first. This PR handles only lines that
are *structurally* unbuyable.

## Verification

`npm run lint` ✅ · `npm run typecheck` ✅ · `npm run build` ✅

There is no test suite in the repo (CI's Test step is `npm test --if-present`, a documented
no-op), so `toCartItem` was exercised directly against all 14 development-catalogue products:

- every product yields a non-null `variantId`
- `variantId` always equals the `#` suffix in the key, for every variant of every product
- multi-variant (`9001`): two sizes → two distinct rows, correct per-variant pricing
- cheapest-variant-sold-out (`9005`): `defaultVariant()` skips `90051`, line carries `90052`
- single-variant (`9003`): `variantId` set, no `— <label>` suffix on the name
- fully sold out (`9009`): still yields a variantId, confirming #92 doesn't guard stock
- variant-less "Coming Soon" tile: `variantId === null`, key has no `#`
- restore filter: drops pre-#92 lines and pre-#20 numeric ids, keeps an explicit `null`
  (`null !== undefined` — a known-absent variant is well-formed; #31 rejects it later)

Bundle cards confirmed rendering as `<a href="/store">` against a running dev server.

> **Note for the reviewer:** `next dev` appends a `nextjs-agent-rules` block to `CLAUDE.md`. I
> stripped it so this PR stays focused — it regenerates on the next `next dev` run. Worth
> committing separately if you want a clean tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0135pq3mk9wVb8YWb6EVzufp
