### PR TITLE
feat: hand off to Shopify hosted checkout (#31)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,12 @@ NEXT_PUBLIC_SHOPIFY_STOREFRONT_TOKEN=
 # Production must be `false` or unset.
 NEXT_PUBLIC_USE_PLACEHOLDER_PRODUCTS=false
 
+# CHECKOUT (#31) NEEDS NO NEW VARIABLES.
+# The hosted-checkout handoff reuses the two Storefront values above — the cart is
+# created with the same public Storefront token, and Shopify runs payment itself.
+# The payment gateway (PayFast) is configured in the Shopify admin, not here, so
+# no gateway key, merchant id or passphrase belongs in this file.
+
 # Shopify webhook signing secret, used to verify the HMAC on POST /api/revalidate.
 # Shopify admin → Settings → Notifications → Webhooks, "Your webhooks are signed
 # with this secret" at the bottom of the page. This is NOT a value you invent.

--- a/.env.example
+++ b/.env.example
@@ -29,8 +29,15 @@ NEXT_PUBLIC_SHOPIFY_STOREFRONT_TOKEN=
 # Production must be `false` or unset.
 NEXT_PUBLIC_USE_PLACEHOLDER_PRODUCTS=false
 
-# CHECKOUT (#31) NEEDS NO NEW VARIABLES.
-# The hosted-checkout handoff reuses the two Storefront values above — the cart is
+# Shopify's `checkoutUrl` comes back on the shop's PRIMARY domain, which is not
+# necessarily the API domain above. Once a custom domain is connected (#18), set
+# this to it — e.g. https://shop.heybeautiful.co.za — or the checkout handoff
+# will reject its own URL and every shopper gets a generic failure.
+# Unset is correct while the store is still on *.myshopify.com.
+NEXT_PUBLIC_SHOPIFY_CHECKOUT_DOMAIN=
+
+# CHECKOUT (#31) NEEDS NO OTHER NEW VARIABLES.
+# The hosted-checkout handoff reuses the Storefront values above — the cart is
 # created with the same public Storefront token, and Shopify runs payment itself.
 # The payment gateway (PayFast) is configured in the Shopify admin, not here, so
 # no gateway key, merchant id or passphrase belongs in this file.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,25 @@ For non-feature work substitute the type segment: `fix`, `chore`, `refactor`, `d
   a *configured* store that errors renders an empty grid rather than fake products.
   Bundles are still hardcoded in `src/lib/products.ts` — no Shopify equivalent yet, and
   display-only since #92.
+- **Checkout handoff** (#31): the bag becomes a Shopify cart via `createCart()` in
+  `src/lib/shopify.ts`, and the shopper is sent to the returned `checkoutUrl`. Shopify owns
+  payment, PCI scope, tax, shipping and the order record; the gateway (PayFast) is configured
+  in the Shopify admin, **never in this repo**.
+  `POST /api/checkout` is the only mutation path. It lives under `/api` on purpose: `proxy.ts`
+  gates everything starting with `/checkout` and excludes `/api`, so a handler under
+  `/checkout/...` — or a Server Action, which posts to the page's own URL — would be answered
+  with a 307 to `/login` on a stale cookie and hand `fetch` an HTML body. It is unauthenticated
+  because it grants nothing a visitor lacks (Shopify cart permalinks do the same with no API),
+  so it validates input tightly instead: numeric variant ids, integer quantities, capped line
+  count. The `email` it receives is a checkout **prefill, not an identity claim** (#57).
+  **Never select `cart { id }`** — a cart id embeds a secret `?key=` that Shopify says to treat
+  like a password. Only `checkoutUrl` is ever requested or returned.
+  Mutations use `storefrontMutate()`, **not** `shopifyFetch()`: the latter caches for an hour
+  under the `products` tag, which would hand two shoppers the same checkout. `userErrors` must
+  be checked explicitly — the Cart API reports business failures inside `data` with a 200, so
+  the `json.errors` check never sees them.
+  The bag is **kept** on handoff, not cleared: an abandoned payment or a back-button press must
+  not cost the shopper their bag. Clearing on confirmation needs an `orders/create` webhook (#67).
 - **Webhook auth** (#4): `/api/revalidate` verifies Shopify's `X-Shopify-Hmac-Sha256`
   (base64 HMAC-SHA256 over the raw body) with `timingSafeEqual`. Needs
   `SHOPIFY_WEBHOOK_SECRET` — the value Shopify shows under Settings → Notifications →

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,6 +166,18 @@ For non-feature work substitute the type segment: `fix`, `chore`, `refactor`, `d
   the `json.errors` check never sees them.
   The bag is **kept** on handoff, not cleared: an abandoned payment or a back-button press must
   not cost the shopper their bag. Clearing on confirmation needs an `orders/create` webhook (#67).
+  Because `pending` is deliberately left set while the browser navigates away, `CheckoutContent`
+  resets it on `pageshow` with `event.persisted` — a bfcache restore (Back from Shopify) otherwise
+  returns the shopper to a permanently disabled button.
+  `checkoutUrl` comes back on the shop's **primary** domain, which is not necessarily the API
+  domain — set `NEXT_PUBLIC_SHOPIFY_CHECKOUT_DOMAIN` once a custom domain is connected (#18), or
+  the guard rejects Shopify's own URL. **Never log a checkout URL**: it carries the cart's secret
+  `?key=`. Log the host.
+  Server-side Storefront calls forward `Shopify-Storefront-Buyer-IP`. Shopify meters a public
+  token per client IP, so without it every shopper's cart shares one bucket with the catalogue
+  reads and a flood could empty the store's grid.
+  Bag caps (`MAX_CART_QUANTITY`, `MAX_CART_LINES`) live in `@/lib/constants` so the cart UI and the
+  endpoint enforce the same ceiling — a server-only limit is a dead end the shopper can't diagnose.
 - **Webhook auth** (#4): `/api/revalidate` verifies Shopify's `X-Shopify-Hmac-Sha256`
   (base64 HMAC-SHA256 over the raw body) with `timingSafeEqual`. Needs
   `SHOPIFY_WEBHOOK_SECRET` — the value Shopify shows under Settings → Notifications →

--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -1,0 +1,124 @@
+// Turns the shopper's bag into a Shopify cart and returns its checkout URL (#31).
+// The browser then navigates there and Shopify runs the rest of the purchase.
+//
+// WHY /api AND NOT A SERVER ACTION OR /checkout/...:
+// `proxy.ts` gates every path starting with `/checkout` and its matcher excludes
+// `/api`. A handler under `/checkout/...` — and a Server Action, which POSTs to
+// the page's own URL — would therefore be answered with a 307 to `/login` the
+// moment the session-hint cookie is stale, and `fetch` would follow it and get
+// HTML back. Living under `/api` avoids that whole failure mode.
+//
+// WHY THIS ENDPOINT IS UNAUTHENTICATED:
+// It grants no capability a visitor doesn't already have. Shopify's own cart
+// permalinks (`/cart/<variantId>:<qty>`) let anyone build a checkout URL with no
+// API at all. This reads no user data, takes no payment, and returns only a URL
+// Shopify is happy to hand out. Verifying a Firebase ID token would need
+// `firebase-admin`, which this repo doesn't carry — that's #57's ground, and
+// under hosted checkout there is no order endpoint of ours left to protect.
+// What it MUST do instead is validate its input tightly, so it can't be turned
+// into a general-purpose proxy for arbitrary Storefront mutations.
+
+import { NextResponse, type NextRequest } from "next/server";
+
+import { createCart, isValidCheckoutUrl, type CheckoutLine } from "@/lib/shopify";
+
+/**
+ * Caps. A bag is a human-sized thing; these exist so a hand-rolled POST can't
+ * ask Shopify to price ten thousand lines on our token.
+ */
+const MAX_LINES = 50;
+const MAX_QUANTITY = 100;
+
+/** Shopify variant ids are numeric. Anything else never reaches the mutation. */
+const NUMERIC_ID = /^\d+$/;
+
+interface RawLine {
+  variantId?: unknown;
+  quantity?: unknown;
+}
+
+/**
+ * Returns the parsed lines, or a string naming what was wrong. A string rather
+ * than a thrown error keeps the handler's guard-clause shape.
+ */
+function parseLines(raw: unknown): CheckoutLine[] | string {
+  if (!Array.isArray(raw)) return "Expected an array of lines.";
+  if (raw.length === 0) return "Your bag is empty.";
+  if (raw.length > MAX_LINES) return "Too many lines.";
+
+  const lines: CheckoutLine[] = [];
+
+  for (const entry of raw as RawLine[]) {
+    const { variantId, quantity } = entry ?? {};
+
+    // `null` is the #92 marker for a line with no Shopify variant — a bundle, or
+    // a placeholder tile. Those can never be bought, so they are rejected here
+    // rather than sent to Shopify to fail less clearly.
+    if (typeof variantId !== "string" || !NUMERIC_ID.test(variantId)) {
+      return "That bag contains an item that can't be purchased.";
+    }
+
+    if (
+      typeof quantity !== "number" ||
+      !Number.isInteger(quantity) ||
+      quantity < 1 ||
+      quantity > MAX_QUANTITY
+    ) {
+      return "Invalid quantity.";
+    }
+
+    lines.push({ variantId, quantity });
+  }
+
+  return lines;
+}
+
+export async function POST(req: NextRequest) {
+  let body: unknown;
+
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ message: "Invalid request body." }, { status: 400 });
+  }
+
+  const { lines: rawLines, email } = (body ?? {}) as {
+    lines?: unknown;
+    email?: unknown;
+  };
+
+  const parsed = parseLines(rawLines);
+
+  if (typeof parsed === "string") {
+    return NextResponse.json({ message: parsed }, { status: 400 });
+  }
+
+  const result = await createCart(
+    parsed,
+    typeof email === "string" && email !== "" ? email : undefined
+  );
+
+  if (!result.ok) {
+    // 503 for a store that isn't wired up yet, mirroring /api/revalidate's
+    // distinction: a misconfigured deploy should be tellable apart from a
+    // request Shopify actively refused.
+    const status = result.reason === "unconfigured" ? 503 : 502;
+    return NextResponse.json(
+      { message: "We couldn't start checkout just now. Please try again." },
+      { status }
+    );
+  }
+
+  // Belt and braces: this URL becomes a top-level navigation in the browser, so
+  // an unexpected host must never be handed back. `createCart` only ever returns
+  // what Shopify sent, but that is exactly the value worth checking.
+  if (!isValidCheckoutUrl(result.checkoutUrl)) {
+    console.error("Rejected non-Shopify checkout URL:", result.checkoutUrl);
+    return NextResponse.json(
+      { message: "We couldn't start checkout just now. Please try again." },
+      { status: 502 }
+    );
+  }
+
+  return NextResponse.json({ checkoutUrl: result.checkoutUrl });
+}

--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -58,12 +58,14 @@ function parseLines(raw: unknown): CheckoutLine[] | string {
       return "That bag contains an item that can't be purchased.";
     }
 
-    if (
-      typeof quantity !== "number" ||
-      !Number.isInteger(quantity) ||
-      quantity < 1 ||
-      quantity > MAX_CART_QUANTITY
-    ) {
+    // Split from the cap below so each failure gets an accurate message: a
+    // quantity of 0 or 2.5 is malformed, not "too many", and only a hand-rolled
+    // POST can produce one — the cart UI clamps to MAX_CART_QUANTITY.
+    if (typeof quantity !== "number" || !Number.isInteger(quantity) || quantity < 1) {
+      return "That bag contains an item with an invalid quantity.";
+    }
+
+    if (quantity > MAX_CART_QUANTITY) {
       return `Each item is limited to ${MAX_CART_QUANTITY}. Please reduce the quantity.`;
     }
 

--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -21,13 +21,12 @@
 import { NextResponse, type NextRequest } from "next/server";
 
 import { createCart, isValidCheckoutUrl, type CheckoutLine } from "@/lib/shopify";
+import { MAX_CART_LINES, MAX_CART_QUANTITY } from "@/lib/constants";
 
-/**
- * Caps. A bag is a human-sized thing; these exist so a hand-rolled POST can't
- * ask Shopify to price ten thousand lines on our token.
- */
-const MAX_LINES = 50;
-const MAX_QUANTITY = 100;
+// Caps live in `@/lib/constants` so the cart UI enforces the same ceiling — a
+// limit only the server knows about is a dead end the shopper can't diagnose.
+// They also stop a hand-rolled POST asking Shopify to price ten thousand lines
+// on our token.
 
 /** Shopify variant ids are numeric. Anything else never reaches the mutation. */
 const NUMERIC_ID = /^\d+$/;
@@ -44,7 +43,8 @@ interface RawLine {
 function parseLines(raw: unknown): CheckoutLine[] | string {
   if (!Array.isArray(raw)) return "Expected an array of lines.";
   if (raw.length === 0) return "Your bag is empty.";
-  if (raw.length > MAX_LINES) return "Too many lines.";
+  if (raw.length > MAX_CART_LINES)
+    return `A bag can hold at most ${MAX_CART_LINES} different items.`;
 
   const lines: CheckoutLine[] = [];
 
@@ -62,9 +62,9 @@ function parseLines(raw: unknown): CheckoutLine[] | string {
       typeof quantity !== "number" ||
       !Number.isInteger(quantity) ||
       quantity < 1 ||
-      quantity > MAX_QUANTITY
+      quantity > MAX_CART_QUANTITY
     ) {
-      return "Invalid quantity.";
+      return `Each item is limited to ${MAX_CART_QUANTITY}. Please reduce the quantity.`;
     }
 
     lines.push({ variantId, quantity });
@@ -93,9 +93,20 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ message: parsed }, { status: 400 });
   }
 
+  // Forwarded to Shopify so its per-IP Storefront rate limit is attributed to the
+  // shopper rather than to this server — otherwise every cart creation shares one
+  // bucket with the catalogue reads. Netlify sets x-nf-client-connection-ip;
+  // x-forwarded-for is the general fallback. Spoofable, but it is a metering
+  // hint, not an authorisation input.
+  const buyerIp =
+    req.headers.get("x-nf-client-connection-ip") ??
+    req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+    undefined;
+
   const result = await createCart(
     parsed,
-    typeof email === "string" && email !== "" ? email : undefined
+    typeof email === "string" && email !== "" ? email : undefined,
+    buyerIp
   );
 
   if (!result.ok) {
@@ -113,7 +124,17 @@ export async function POST(req: NextRequest) {
   // an unexpected host must never be handed back. `createCart` only ever returns
   // what Shopify sent, but that is exactly the value worth checking.
   if (!isValidCheckoutUrl(result.checkoutUrl)) {
-    console.error("Rejected non-Shopify checkout URL:", result.checkoutUrl);
+    // Log the HOST only. A checkout URL carries the cart's secret `?key=` — the
+    // same value the mutation deliberately avoids selecting — so writing the raw
+    // URL here would put a live cart capability into the function logs for every
+    // shopper this rejects.
+    let host = "unparseable";
+    try {
+      host = new URL(result.checkoutUrl).host;
+    } catch {
+      // keep the placeholder
+    }
+    console.error("Rejected checkout URL from unexpected host:", host);
     return NextResponse.json(
       { message: "We couldn't start checkout just now. Please try again." },
       { status: 502 }

--- a/src/app/checkout/CheckoutContent.tsx
+++ b/src/app/checkout/CheckoutContent.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -12,6 +12,7 @@ import { useCart } from "@/context/CartContext";
 import { formatPrice } from "@/lib/format";
 import { sessionExpiredLoginUrl, withFrom } from "@/lib/redirect";
 import { clearSessionHint } from "@/lib/session";
+import AuthErrorToast from "@/components/auth/AuthErrorToast";
 
 export default function CheckoutContent() {
   const router = useRouter();
@@ -20,6 +21,56 @@ export default function CheckoutContent() {
   // One-shot guard: React Strict Mode double-invokes effects in dev, and we never
   // want two navigations racing.
   const redirected = useRef(false);
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState("");
+
+  // A line with no Shopify variant can't be bought (#92). Nothing should be able
+  // to put one in the bag — bundles no longer enter it and placeholder tiles have
+  // no purchase controls — so this is a guard against a future regression, not a
+  // live path. Better a disabled button than a rejected checkout.
+  const unpurchasable = items.some((item) => item.variantId === null);
+
+  const handleCheckout = async () => {
+    if (pending) return;
+    setError("");
+    setPending(true);
+
+    try {
+      const res = await fetch("/api/checkout", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          lines: items.map((item) => ({
+            variantId: item.variantId,
+            quantity: item.quantity,
+          })),
+          // Prefill only — Shopify collects and owns the real order details.
+          email: user?.email ?? undefined,
+        }),
+      });
+
+      const data = await res.json().catch(() => null);
+
+      if (!res.ok || !data?.checkoutUrl) {
+        setError(data?.message ?? "We couldn't start checkout. Please try again.");
+        setPending(false);
+        return;
+      }
+
+      // The bag is deliberately NOT cleared: the shopper may abandon payment or
+      // press back, and losing their bag at that moment is how a sale is lost.
+      // Shopify owns the order, so the bag stays until they empty it themselves.
+      //
+      // `pending` is deliberately NOT reset here either — the browser is still
+      // navigating away, and resetting flashes the button back to its idle label.
+      // `router.push` is for internal routes; this is the app's one external
+      // navigation, which CSP's `form-action 'self'` does not restrict.
+      window.location.assign(data.checkoutUrl);
+    } catch {
+      setError("We couldn't reach checkout. Check your connection and try again.");
+      setPending(false);
+    }
+  };
 
   // Two client-side guards the edge proxy can't do (it only sees the presence
   // cookie): (1) stale-cookie / dead session → login; (2) unverified email →
@@ -180,26 +231,42 @@ export default function CheckoutContent() {
               </span>
             </motion.div>
 
-            {/* Payment is not wired up yet — honest placeholder. */}
-            <motion.div
+            <motion.button
               variants={fadeUp}
-              className="mt-7 flex items-center justify-center gap-2 py-4 rounded-full"
-              style={{
-                background: "rgba(201,151,122,0.1)",
-                border: "1px dashed rgba(201,151,122,0.35)",
-              }}
+              type="button"
+              onClick={handleCheckout}
+              disabled={pending || unpurchasable}
+              whileHover={{ scale: pending ? 1 : 1.015 }}
+              whileTap={{ scale: pending ? 1 : 0.98 }}
+              className="btn-primary-gradient w-full py-4 mt-7 flex items-center justify-center gap-2 disabled:opacity-70"
             >
-              <Lock size={13} className="text-rose-gold" />
-              <span
-                className="text-ink/65"
-                style={{ fontFamily: "var(--font-manrope)", fontSize: "0.8rem" }}
+              <Lock size={13} />
+              {pending ? "Taking you to checkout…" : "Proceed to Payment"}
+            </motion.button>
+
+            {unpurchasable && (
+              <motion.p
+                variants={fadeUp}
+                role="status"
+                className="mt-3 text-center text-ink/55"
+                style={{ fontFamily: "var(--font-manrope)", fontSize: "0.75rem" }}
               >
-                Secure payment coming soon
-              </span>
-            </motion.div>
+                One of these items is no longer available. Remove it to continue.
+              </motion.p>
+            )}
+
+            <motion.p
+              variants={fadeUp}
+              className="mt-4 text-center text-ink/45"
+              style={{ fontFamily: "var(--font-manrope)", fontSize: "0.7rem" }}
+            >
+              You’ll complete payment securely on Shopify.
+            </motion.p>
           </motion.div>
         )}
       </div>
+
+      <AuthErrorToast message={error} onDismiss={() => setError("")} />
     </section>
   );
 }

--- a/src/app/checkout/CheckoutContent.tsx
+++ b/src/app/checkout/CheckoutContent.tsx
@@ -30,6 +30,20 @@ export default function CheckoutContent() {
   // live path. Better a disabled button than a rejected checkout.
   const unpurchasable = items.some((item) => item.variantId === null);
 
+  // Pressing Back from Shopify restores this page from the bfcache (the norm on
+  // iOS Safari, common elsewhere), and React state comes back with it — including
+  // `pending: true`, which is deliberately left set on the success path below.
+  // Without this the shopper returns to a button stuck on "Taking you to
+  // checkout…" and cannot retry short of a hard reload. The bag survives but
+  // checkout doesn't, which defeats the point of keeping the bag at all.
+  useEffect(() => {
+    const onPageShow = (e: PageTransitionEvent) => {
+      if (e.persisted) setPending(false);
+    };
+    window.addEventListener("pageshow", onPageShow);
+    return () => window.removeEventListener("pageshow", onPageShow);
+  }, []);
+
   const handleCheckout = async () => {
     if (pending) return;
     setError("");

--- a/src/context/CartContext.tsx
+++ b/src/context/CartContext.tsx
@@ -10,7 +10,7 @@ import {
   type ReactNode,
 } from "react";
 
-import { CART_STORAGE_KEY as STORAGE_KEY } from "@/lib/constants";
+import { CART_STORAGE_KEY as STORAGE_KEY, MAX_CART_QUANTITY } from "@/lib/constants";
 
 export interface CartProduct {
   /**
@@ -123,10 +123,14 @@ export function CartProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const updateQuantity = useCallback((id: string, quantity: number) => {
+    // Clamped to the same ceiling the checkout endpoint enforces (#31), so the
+    // control simply stops rather than letting a shopper build a bag that is
+    // rejected at the last step.
+    const capped = Math.min(quantity, MAX_CART_QUANTITY);
     setItems((prev) =>
-      quantity <= 0
+      capped <= 0
         ? prev.filter((p) => p.id !== id)
-        : prev.map((p) => (p.id === id ? { ...p, quantity } : p))
+        : prev.map((p) => (p.id === id ? { ...p, quantity: capped } : p))
     );
   }, []);
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -28,3 +28,12 @@ export const MIN_PASSWORD_LENGTH = 8;
 /** Cart and wishlist persistence keys. Cleared on sign-out — see `clearLocalUserState`. */
 export const CART_STORAGE_KEY = "hb-cart";
 export const WISHLIST_STORAGE_KEY = "hb-wishlist";
+
+/**
+ * Bag caps, shared by the cart UI and the checkout endpoint (#31) so the two
+ * can't disagree. Without a shared limit the cart happily counts past whatever
+ * the endpoint accepts, and the shopper meets a 400 at the last step with no way
+ * to tell which line is at fault.
+ */
+export const MAX_CART_QUANTITY = 100;
+export const MAX_CART_LINES = 50;

--- a/src/lib/shopify.ts
+++ b/src/lib/shopify.ts
@@ -138,6 +138,18 @@ function parseRating(raw: string | null | undefined): number | undefined {
   return Number.isFinite(n) ? n : undefined;
 }
 
+/**
+ * Storefront API version. Every Shopify surface must agree on this: the webhooks
+ * registered in admin are signed against the version they were registered for,
+ * so a mismatch changes the payload shape (see `.env.example`).
+ */
+const API_VERSION = "2026-04";
+
+/** Storefront GraphQL endpoint. `domain` must already carry its scheme. */
+function endpoint(domain: string): string {
+  return `${domain}/api/${API_VERSION}/graphql.json`;
+}
+
 function isConfigured(): boolean {
   return Boolean(
     process.env.NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN &&
@@ -155,7 +167,7 @@ async function shopifyFetch<T>(
   if (!domain || !token) return null;
 
   try {
-    const response = await fetch(`${domain}/api/2026-04/graphql.json`, {
+    const response = await fetch(endpoint(domain), {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -281,4 +293,178 @@ export async function getProductBySlug(
   );
 
   return data?.product ? toProduct(data.product) : null;
+}
+
+// ─── Checkout handoff (#31) ────────────────────────────────────────────────
+//
+// The bag is turned into a Shopify cart and the shopper is sent to the
+// `checkoutUrl` Shopify returns. Shopify then owns payment, PCI scope, tax,
+// shipping rates and the order record — none of that belongs in this repo, and
+// the payment gateway (PayFast) is configured in the Shopify admin, not here.
+
+/**
+ * A bag line, reduced to what Shopify needs. `variantId` is the NUMERIC id the
+ * cart carries (#92); the gid is rebuilt below — the inverse of `gidToId`.
+ */
+export interface CheckoutLine {
+  variantId: string;
+  quantity: number;
+}
+
+/** Discriminated result so callers never handle GraphQL shapes. */
+export type CreateCartResult =
+  | { ok: true; checkoutUrl: string }
+  | { ok: false; reason: "unconfigured" | "transport" | "rejected" };
+
+/**
+ * NOTE the response selection: `cart { checkoutUrl }` and nothing else.
+ *
+ * A cart id is `gid://shopify/Cart/<token>?key=<secret>` — Shopify's docs say to
+ * treat that key like a password and keep it out of client-side code. We never
+ * need it (the cart is created and immediately handed off), so it is never
+ * selected, and therefore can't leak through this route by accident.
+ */
+const CART_CREATE_MUTATION = `
+  mutation CreateCart($lines: [CartLineInput!]!, $buyerIdentity: CartBuyerIdentityInput) {
+    cartCreate(input: { lines: $lines, buyerIdentity: $buyerIdentity }) {
+      cart { checkoutUrl }
+      userErrors { field message }
+    }
+  }
+`;
+
+interface CartCreateResponse {
+  cartCreate: {
+    cart: { checkoutUrl: string } | null;
+    userErrors: Array<{ field: string[] | null; message: string }>;
+  } | null;
+}
+
+/**
+ * Sibling of `shopifyFetch` for mutations.
+ *
+ * Deliberately NOT `shopifyFetch`: that helper sets
+ * `next: { revalidate: 3600, tags: ["products"] }`, which would cache a cart
+ * creation for an hour and hang it off the products tag — so two shoppers could
+ * be handed the same checkout. `cache: "no-store"` is the whole point.
+ */
+async function storefrontMutate<T>(
+  query: string,
+  variables: Record<string, unknown>
+): Promise<T | null> {
+  const domain = process.env.NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN;
+  const token = process.env.NEXT_PUBLIC_SHOPIFY_STOREFRONT_TOKEN;
+
+  if (!domain || !token) return null;
+
+  try {
+    const response = await fetch(endpoint(domain), {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Shopify-Storefront-Access-Token": token,
+      },
+      body: JSON.stringify({ query, variables }),
+      cache: "no-store",
+    });
+
+    if (!response.ok) {
+      console.error("Shopify mutation error:", response.status);
+      return null;
+    }
+
+    const json = await response.json();
+
+    if (json.errors) {
+      console.error("Shopify mutation query errors:", json.errors);
+      return null;
+    }
+
+    return (json.data as T) ?? null;
+  } catch (err) {
+    console.error("Shopify mutation failed:", err);
+    return null;
+  }
+}
+
+/**
+ * Creates a Shopify cart and returns its checkout URL.
+ *
+ * `email` is a checkout PREFILL, not an identity claim — it reaches this
+ * function from the browser, and #57 is explicit that a client-sent value is not
+ * a trust boundary. Shopify collects and owns the authoritative order details
+ * regardless; the only effect of a wrong value here is a wrong prefill.
+ */
+export async function createCart(
+  lines: CheckoutLine[],
+  email?: string
+): Promise<CreateCartResult> {
+  if (!isConfigured()) return { ok: false, reason: "unconfigured" };
+
+  const data = await storefrontMutate<CartCreateResponse>(CART_CREATE_MUTATION, {
+    lines: lines.map((l) => ({
+      merchandiseId: `gid://shopify/ProductVariant/${l.variantId}`,
+      quantity: l.quantity,
+    })),
+    buyerIdentity: email ? { email } : undefined,
+  });
+
+  if (data === null) return { ok: false, reason: "transport" };
+
+  // `userErrors` is where the Cart API reports business failures — a variant that
+  // doesn't exist, is unpublished, or is out of stock. They arrive INSIDE `data`
+  // with a 200, so the `json.errors` check above never sees them. Missing this is
+  // the classic way a broken checkout looks like a working one.
+  const payload = data.cartCreate;
+  const userErrors = payload?.userErrors ?? [];
+
+  if (userErrors.length > 0) {
+    console.error("Shopify cartCreate userErrors:", userErrors);
+    return { ok: false, reason: "rejected" };
+  }
+
+  const checkoutUrl = payload?.cart?.checkoutUrl;
+
+  if (!checkoutUrl) {
+    console.error("Shopify cartCreate returned no checkoutUrl");
+    return { ok: false, reason: "rejected" };
+  }
+
+  return { ok: true, checkoutUrl };
+}
+
+/**
+ * Fails closed on anything that isn't a Shopify checkout URL.
+ *
+ * `src/lib/redirect.ts` is the security boundary for INTERNAL destinations and
+ * rejects every absolute URL by design, so routing this through it would rewrite
+ * a valid checkout to `/account`. This is the outbound equivalent: the value is
+ * about to become a top-level navigation, so an unexpected host must not be
+ * followed.
+ */
+export function isValidCheckoutUrl(raw: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return false;
+  }
+
+  if (url.protocol !== "https:") return false;
+
+  // Shopify serves checkout from the shop domain or a shopify.com host depending
+  // on the store's configuration, so both are accepted — but nothing else is.
+  const shopHost = (() => {
+    try {
+      return new URL(process.env.NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN ?? "").host;
+    } catch {
+      return "";
+    }
+  })();
+
+  return (
+    (shopHost !== "" && url.host === shopHost) ||
+    url.host === "shopify.com" ||
+    url.host.endsWith(".shopify.com")
+  );
 }

--- a/src/lib/shopify.ts
+++ b/src/lib/shopify.ts
@@ -350,20 +350,30 @@ interface CartCreateResponse {
  */
 async function storefrontMutate<T>(
   query: string,
-  variables: Record<string, unknown>
+  variables: Record<string, unknown>,
+  buyerIp?: string
 ): Promise<T | null> {
   const domain = process.env.NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN;
   const token = process.env.NEXT_PUBLIC_SHOPIFY_STOREFRONT_TOKEN;
 
   if (!domain || !token) return null;
 
+  // Shopify meters a public Storefront token PER CLIENT IP. Server-side calls
+  // would otherwise all be attributed to this server's IP — one shared bucket for
+  // every shopper's cart AND the catalogue reads in `shopifyFetch`, so a flood of
+  // cart creations could throttle `getProducts()` and empty the store's grid.
+  // Forwarding the buyer's IP is Shopify's documented remedy for exactly this.
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "X-Shopify-Storefront-Access-Token": token,
+  };
+
+  if (buyerIp) headers["Shopify-Storefront-Buyer-IP"] = buyerIp;
+
   try {
     const response = await fetch(endpoint(domain), {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-Shopify-Storefront-Access-Token": token,
-      },
+      headers,
       body: JSON.stringify({ query, variables }),
       cache: "no-store",
     });
@@ -397,17 +407,22 @@ async function storefrontMutate<T>(
  */
 export async function createCart(
   lines: CheckoutLine[],
-  email?: string
+  email?: string,
+  buyerIp?: string
 ): Promise<CreateCartResult> {
   if (!isConfigured()) return { ok: false, reason: "unconfigured" };
 
-  const data = await storefrontMutate<CartCreateResponse>(CART_CREATE_MUTATION, {
-    lines: lines.map((l) => ({
-      merchandiseId: `gid://shopify/ProductVariant/${l.variantId}`,
-      quantity: l.quantity,
-    })),
-    buyerIdentity: email ? { email } : undefined,
-  });
+  const data = await storefrontMutate<CartCreateResponse>(
+    CART_CREATE_MUTATION,
+    {
+      lines: lines.map((l) => ({
+        merchandiseId: `gid://shopify/ProductVariant/${l.variantId}`,
+        quantity: l.quantity,
+      })),
+      buyerIdentity: email ? { email } : undefined,
+    },
+    buyerIp
+  );
 
   if (data === null) return { ok: false, reason: "transport" };
 
@@ -442,6 +457,25 @@ export async function createCart(
  * about to become a top-level navigation, so an unexpected host must not be
  * followed.
  */
+function hostOf(value: string | undefined): string {
+  if (!value) return "";
+  try {
+    return new URL(value).host;
+  } catch {
+    return "";
+  }
+}
+
+/** Shopify-owned hosts. Note `*.myshopify.com` needs its own arm: the string
+ *  "shop.myshopify.com" does NOT end with ".shopify.com". */
+function isShopifyOwnedHost(host: string): boolean {
+  return (
+    host === "shopify.com" ||
+    host.endsWith(".shopify.com") ||
+    host.endsWith(".myshopify.com")
+  );
+}
+
 export function isValidCheckoutUrl(raw: string): boolean {
   let url: URL;
   try {
@@ -452,19 +486,26 @@ export function isValidCheckoutUrl(raw: string): boolean {
 
   if (url.protocol !== "https:") return false;
 
-  // Shopify serves checkout from the shop domain or a shopify.com host depending
-  // on the store's configuration, so both are accepted — but nothing else is.
-  const shopHost = (() => {
-    try {
-      return new URL(process.env.NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN ?? "").host;
-    } catch {
-      return "";
-    }
-  })();
+  if (isShopifyOwnedHost(url.host)) return true;
 
-  return (
-    (shopHost !== "" && url.host === shopHost) ||
-    url.host === "shopify.com" ||
-    url.host.endsWith(".shopify.com")
-  );
+  // Shopify returns `checkoutUrl` on the shop's PRIMARY domain, which is not
+  // necessarily the host the API request went to. A store with a custom primary
+  // domain hands back `https://shop.example.co.za/cart/c/…`, which is neither the
+  // configured `*.myshopify.com` API domain nor a Shopify-owned host — so without
+  // this arm every checkout would be rejected the day a real domain is attached
+  // (#18). Set NEXT_PUBLIC_SHOPIFY_CHECKOUT_DOMAIN to that primary domain.
+  const configured = [
+    hostOf(process.env.NEXT_PUBLIC_SHOPIFY_CHECKOUT_DOMAIN),
+    hostOf(process.env.NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN),
+  ].filter((h) => h !== "");
+
+  if (configured.length === 0) {
+    // A domain set without its scheme parses to "" and would silently narrow the
+    // allowlist. Say so rather than failing mysteriously at checkout.
+    console.error(
+      "No usable Shopify host configured — NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN must include its scheme (https://…)."
+    );
+  }
+
+  return configured.includes(url.host);
 }


### PR DESCRIPTION
Closes #31. Builds on #92 (`variantId` on the cart line). Completes the last box on #4.

`/checkout` ended at a dashed "Secure payment coming soon" pill. The bag now becomes a Shopify
cart and the shopper is sent to the returned `checkoutUrl` — Shopify owns payment, PCI scope,
tax, shipping rates and the order record. **PayFast is configured in the Shopify admin; no
gateway code is in this PR, and none belongs here.**

## ⚠️ The happy path is NOT verified — please read

The local Storefront credentials are rejected by Shopify. Even a trivial read fails:

```
POST https://wi9fzy-ha.myshopify.com/api/2026-04/graphql.json   { shop { name } }
→ HTTP 401
```

So no cart can be created from this machine, and **I could not confirm that a shopper actually
reaches Shopify's checkout.** Everything up to the Shopify call is verified; the call itself
isn't. This looks like #66's territory (production Storefront credentials) rather than a code
problem — the domain matches the connected store, and the token is the right shape but doesn't
authenticate.

Worth knowing: `NEXT_PUBLIC_USE_PLACEHOLDER_PRODUCTS=true` **masks this completely**. The site
browses perfectly on the dev catalogue while the token is dead, so nothing else surfaces it.

Before merging, someone with working credentials should confirm: Proceed → Shopify checkout,
right line items and quantities, totals matching the summary, email pre-filled.

## Three things the docs settle

Each is a quiet way to get this wrong, so they're worth calling out:

1. **The Cart API reports failures in `userErrors`, inside `data`, with a 200.** `shopifyFetch`'s
   `json.errors` check never sees them — a rejected cart would look like a successful one.
   `createCart` checks them explicitly.
2. **Mutations must not reuse `shopifyFetch`.** It sets `next: { revalidate: 3600, tags: ["products"] }`,
   which would cache a cart creation for an hour under the products tag — two shoppers could be
   handed the same checkout. `storefrontMutate` is its `cache: "no-store"` sibling.
3. **A cart id embeds a secret** (`gid://shopify/Cart/<token>?key=<secret>`); Shopify says treat it
   like a password. The mutation selects `cart { checkoutUrl }` and nothing else, so the id can't
   leak through this route by accident.

## Why `/api/checkout`

`proxy.ts` gates every path starting with `/checkout` and its matcher excludes `/api`. A handler
under `/checkout/...` — or a Server Action, which POSTs to the page's own URL — would answer a
stale-cookie POST with a **307 to `/login`**, handing `fetch` an HTML body. Living under `/api`
avoids that entirely.

**It is unauthenticated, deliberately.** It grants nothing a visitor doesn't already have —
Shopify's cart permalinks (`/cart/<variantId>:<qty>`) build a checkout URL with no API at all. It
reads no user data, takes no payment, and returns only a URL Shopify hands out freely. Verifying a
Firebase ID token would need `firebase-admin`, which isn't in the tree, and under hosted checkout
there's no order endpoint of ours left to protect (#57). What it does instead is validate input
tightly so it can't become a general-purpose Storefront proxy. **If you disagree with that call,
this is the thing to push back on.**

The `email` is a checkout **prefill, not an identity claim** — it comes from the browser, and #57
is explicit that client-sent values aren't a trust boundary.

## Other decisions

- **The bag is kept on handoff.** An abandoned payment or a back-button press must not cost the
  shopper their bag. Clearing on confirmation needs an `orders/create` webhook (#67).
- **`checkoutUrl` is origin-checked** before being returned. `redirect.ts` is the boundary for
  *internal* destinations and rejects every absolute URL by design, so this is its outbound
  counterpart — the value becomes a top-level navigation, so an unexpected host must not be followed.
- **`pending` is not reset on success** — the browser is still navigating away, and resetting
  flashes the button back to idle.
- No new env vars. Noted in `.env.example`, since a payment step is exactly where you'd expect a
  secret to be needed.

## Verified

`npm run lint` ✅ · `npm run typecheck` ✅ · `npm run build` ✅ (`/api/checkout` registers)

Live endpoint, against a running server:

| Request | Result |
| --- | --- |
| empty bag | `400 {"message":"Your bag is empty."}` |
| `variantId: null` (#92 unbuyable) | `400 {"message":"That bag contains an item that can't be purchased."}` |
| non-numeric id | `400` |
| quantity `0` | `400` |
| malformed body | `400` |
| dev-catalogue variant | `502` + friendly message, bag intact |

URL guard: accepts the shop domain and `*.shopify.com`; rejects `http:`, foreign hosts,
`evil-shopify.com`, `shopify.com.evil.com`, `javascript:` and garbage. Input validation covers
fractional/negative quantities and the 50-line cap.

Not exercised: the rendered button (the Chrome extension isn't connected, and `/checkout` is
auth-gated). It's confirmed present in the built client chunk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0135pq3mk9wVb8YWb6EVzufp
