### PR TITLE
chore: add Google Search Console verification tag (#14)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,6 +32,9 @@ export const metadata: Metadata = {
     "glow supplements",
     "hey beautiful",
   ],
+  verification: {
+    google: "MBRhCK7Z0a31F7y4F5nDhSWbf2aeRMW8RwNshOqNgwk",
+  },
   openGraph: {
     title: "Hey Beautiful — Fuel Your Strength. Keep Your Glow.",
     description:


### PR DESCRIPTION
Adds the Google Search Console verification token so the property can be verified and search
performance tracked once the site is live.

Uses Next's `metadata.verification.google` rather than a hand-written `<meta>` tag, which keeps it
alongside the rest of the site metadata in `layout.tsx` and renders
`<meta name="google-site-verification" ...>` on every page.

### Note on the token

Verification tokens are designed to be publicly readable — the whole mechanism depends on Google
fetching the tag from the public page. It proves ownership only in combination with the Search
Console account, so it is not a credential and does not belong in an env var.

### Scope

First step toward #14. Still outstanding there: `sitemap.ts`, `robots.ts`, and analytics (#16).

`npm run lint` / `typecheck` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0135pq3mk9wVb8YWb6EVzufp