### PR TITLE
feat: add sitemap.xml and robots.txt (#14)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,19 @@ NEXT_PUBLIC_FIREBASE_APP_ID=
 NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN=
 NEXT_PUBLIC_SHOPIFY_STOREFRONT_TOKEN=
 
+# Public origin of THIS site, used for the sitemap, robots.txt and the absolute URLs
+# in Open Graph tags (`metadataBase`). Optional — leave it blank unless you need to
+# override the automatic value.
+#
+# Netlify supplies a working origin on its own: `URL` on production builds and
+# `DEPLOY_PRIME_URL` on deploy previews, which `src/lib/site.ts` reads. Set this only
+# once a custom domain is attached (#18) and you want it quoted instead — for example
+# https://heybeautiful.co.za  (include the scheme, no trailing slash).
+#
+# NEXT_PUBLIC_* values are inlined at BUILD time, so setting this in Netlify needs a
+# NEW BUILD; redeploying an existing one keeps the old value baked in.
+NEXT_PUBLIC_SITE_URL=
+
 # Development product catalogue (#68). Lets the storefront be built and reviewed
 # before the Shopify catalogue is populated.
 #

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,6 +184,19 @@ For non-feature work substitute the type segment: `fix`, `chore`, `refactor`, `d
   `CheckoutContent` (the edge `proxy.ts` can't read Firebase's `emailVerified`), redirecting
   unverified users to `/verify-email?from=<dest>`. `/account` is advisory (soft reminder only).
   `AuthContext.reloadUser()` refreshes `emailVerified`; the verify page polls it to auto-continue.
+- **Site URL and indexing** (#14): `siteUrl()` in `src/lib/site.ts` is the **single** source of
+  the public origin — it feeds both `metadataBase` in `layout.tsx` and `sitemap.ts`, so the two
+  can never quote different hosts. It resolves `NEXT_PUBLIC_SITE_URL` → Netlify's
+  `DEPLOY_PRIME_URL`/`URL` → localhost; **server only**, since those Netlify vars carry no
+  `NEXT_PUBLIC_` prefix and would be `undefined` in a client bundle (which is why it isn't in
+  `@/lib/constants`, imported by the cart and auth contexts). `isIndexableDeploy()` blocks
+  crawling on deploy previews so they can't compete with production as duplicate content; it
+  fails **open** on an unrecognised `CONTEXT`, because silently de-indexing the real site is the
+  worse failure. `robots.ts` keeps its own private-path list rather than importing the proxy's —
+  the proxy is an access boundary, robots.txt is a request to well-behaved crawlers, and sharing
+  a list would imply robots.txt protects something. `sitemap.ts` must keep using the same
+  `filter((p) => p.slug)` predicate as `generateStaticParams`, or it will advertise URLs that
+  have no prerendered page.
 - **Page pattern**: a top-level route is a server `page.tsx` (`<Navbar /> … <Footer />` +
   `metadata`) that renders a `"use client"` `*Content.tsx` for interactivity (see
   `app/account`, `app/checkout`). Route protection lives in `src/proxy.ts` (Next 16 renamed the
@@ -236,3 +249,13 @@ internal modules under two casings and instantiates its prerender `workAsyncStor
 twice, producing `InvariantError: Expected workStore to be initialized` on every page
 during static generation. `next dev` is unaffected. Run builds via `npm run build` from a
 terminal opened in the project folder (which uses the real casing).
+
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Cormorant_Garamond, Manrope } from "next/font/google";
 import "./globals.css";
 import { ClientWrapper } from "@/components/ClientWrapper";
+import { siteUrl } from "@/lib/site";
 
 const cormorant = Cormorant_Garamond({
   subsets: ["latin"],
@@ -19,7 +20,10 @@ const manrope = Manrope({
 });
 
 export const metadata: Metadata = {
-  metadataBase: new URL("https://heybeautiful.com"),
+  // Resolved per deploy rather than hardcoded, so this and `sitemap.ts` can never quote
+  // different origins. The previous literal was heybeautiful.com, which is not connected
+  // yet (#18) — every relative OG image was resolving against a host that doesn't answer.
+  metadataBase: new URL(siteUrl()),
   title: "Hey Beautiful — Fuel Your Strength. Keep Your Glow.",
   description:
     "Premium feminine wellness supplements crafted for the modern woman. Performance meets femininity. Strength meets beauty. Elevate your everyday ritual.",

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,48 @@
+import type { MetadataRoute } from "next";
+
+import { isIndexableDeploy, siteUrl } from "@/lib/site";
+
+/**
+ * Paths that should never appear in search results.
+ *
+ * This list is deliberately NOT imported from `src/proxy.ts`, even though it overlaps its
+ * PROTECTED / AUTH_PAGES arrays. They answer different questions: the proxy is the access
+ * boundary and is enforced, whereas robots.txt is a request to well-behaved crawlers and
+ * enforces nothing. Sharing one list would imply this file protects something. Drift
+ * between them is cosmetic — `src/proxy.ts` remains the source of truth for routing.
+ *
+ * `/verify-email` is here but is intentionally absent from the proxy's AUTH_PAGES, since a
+ * signed-in-but-unverified user has to be able to reach it.
+ */
+const PRIVATE_PATHS = [
+  "/account",
+  "/checkout",
+  "/login",
+  "/signup",
+  "/forgot-password",
+  "/verify-email",
+  "/api/",
+];
+
+export default function robots(): MetadataRoute.Robots {
+  // Deploy previews serve the entire site on a public URL. Left indexable they would
+  // compete with production as duplicate content, so they are closed off wholesale — and
+  // without a `sitemap` line, which would otherwise invite crawling of what was just
+  // disallowed.
+  if (!isIndexableDeploy()) {
+    return {
+      rules: [{ userAgent: "*", disallow: "/" }],
+    };
+  }
+
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: PRIVATE_PATHS,
+      },
+    ],
+    sitemap: `${siteUrl()}/sitemap.xml`,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,42 @@
+import type { MetadataRoute } from "next";
+
+import { getProducts } from "@/lib/shopify";
+import { siteUrl } from "@/lib/site";
+
+/**
+ * Every publicly indexable route. The auth and account pages are excluded here and
+ * disallowed in `robots.ts`.
+ *
+ * `lastModified` is deliberately absent throughout. `ShopifyProduct` carries no date field —
+ * no `updatedAt`, `publishedAt` or `createdAt` — and the obvious substitute, `new Date()`,
+ * would claim every page changed every time this regenerates (hourly). Search engines
+ * discount a `lastModified` they learn to distrust, so omitting it is worth more than
+ * inventing one. Adding a real `updatedAt` to the catalogue fragment would let this carry a
+ * truthful value.
+ */
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const base = siteUrl();
+
+  const staticRoutes: MetadataRoute.Sitemap = [
+    { url: `${base}/`, changeFrequency: "weekly", priority: 1 },
+    { url: `${base}/store`, changeFrequency: "daily", priority: 0.9 },
+  ];
+
+  // `getProducts` never throws: it returns [] for a configured store that errored, and the
+  // "Coming Soon" placeholders when the store isn't configured at all. So a Shopify outage
+  // degrades this to the two static routes rather than failing the build.
+  const products = await getProducts();
+
+  // Same predicate as `generateStaticParams` in `src/app/store/[slug]/page.tsx`. These two
+  // must agree — a sitemap URL with no prerendered page is a 404 handed to a crawler.
+  // It also drops the placeholder tiles, which have no handle and no detail page.
+  const productRoutes: MetadataRoute.Sitemap = products
+    .filter((p) => p.slug)
+    .map((p) => ({
+      url: `${base}/store/${p.slug}`,
+      changeFrequency: "weekly" as const,
+      priority: 0.8,
+    }));
+
+  return [...staticRoutes, ...productRoutes];
+}

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -1,0 +1,54 @@
+/**
+ * The public identity of this deploy: what URL it is reachable at, and whether search
+ * engines should be allowed to index it.
+ *
+ * SERVER ONLY. `CONTEXT`, `URL` and `DEPLOY_PRIME_URL` are Netlify build variables with no
+ * `NEXT_PUBLIC_` prefix, so they are not inlined into client bundles — importing this from
+ * a `"use client"` component would silently resolve every value to the localhost fallback.
+ * That is also why it does not live in `@/lib/constants`, which the cart and auth contexts
+ * import into the browser.
+ */
+
+/** Netlify's own name for the build that is being run. */
+const PREVIEW_CONTEXTS = ["deploy-preview", "branch-deploy", "dev"];
+
+/** Local fallback. Only ever used off-platform, where nothing is being crawled anyway. */
+const LOCAL_URL = "http://localhost:3000";
+
+/**
+ * The absolute origin this deploy is served from, without a trailing slash.
+ *
+ * Resolution order matters. On a Netlify *preview* build both `URL` and `DEPLOY_PRIME_URL`
+ * are set — `URL` is the production site and `DEPLOY_PRIME_URL` is this particular deploy —
+ * so preferring `URL` unconditionally would make every preview advertise production's URLs.
+ *
+ * Set NEXT_PUBLIC_SITE_URL once a custom domain is attached (#18) to override the lot.
+ * Like every NEXT_PUBLIC_ var it is inlined at BUILD time, so changing it on Netlify needs
+ * a new build, not just a redeploy.
+ */
+export function siteUrl(): string {
+  const explicit = process.env.NEXT_PUBLIC_SITE_URL;
+  const netlify =
+    process.env.CONTEXT === "production"
+      ? process.env.URL
+      : process.env.DEPLOY_PRIME_URL ?? process.env.URL;
+
+  const resolved = explicit || netlify || LOCAL_URL;
+
+  return resolved.replace(/\/+$/, "");
+}
+
+/**
+ * Whether crawlers should be allowed to index this deploy at all.
+ *
+ * Deploy previews serve the whole site on a public URL, so without this they compete with
+ * production as duplicate content.
+ *
+ * Note this fails OPEN: only a *recognised* preview context blocks indexing. An unset
+ * `CONTEXT` — local dev, or a host that isn't Netlify — must not quietly de-index the real
+ * site, which is a failure nobody would notice until traffic disappeared.
+ */
+export function isIndexableDeploy(): boolean {
+  const context = process.env.CONTEXT;
+  return context === undefined || !PREVIEW_CONTEXTS.includes(context);
+}


### PR DESCRIPTION
Covers the **Sitemap** and **Robots.txt** boxes on #14. The site previously had neither — no
`sitemap.ts`, no `robots.ts`, no `public/robots.txt` — so crawlers got no guidance at all, and
nothing stopped a Netlify deploy preview being indexed alongside production as duplicate content.

## What's here

| File | Purpose |
| --- | --- |
| `src/lib/site.ts` | **new** — resolves this deploy's public origin, and whether it may be indexed |
| `src/app/robots.ts` | **new** — context-aware rules + sitemap pointer |
| `src/app/sitemap.ts` | **new** — static routes + one URL per real product |
| `src/app/layout.tsx` | `metadataBase` now derives from the same resolver |
| `.env.example` | documents the optional `NEXT_PUBLIC_SITE_URL` |
| `CLAUDE.md` | conventions entry |

## Base URL

Resolved per deploy: `NEXT_PUBLIC_SITE_URL` → Netlify's `DEPLOY_PRIME_URL` / `URL` → localhost.
Ordering matters — on a preview build *both* Netlify vars are set, and `URL` points at production,
so preferring it would make every preview advertise production's URLs.

This works on Netlify today with no configuration. Attaching a real domain (#18) is then a single
env var plus a rebuild, with no code change.

**`src/lib/site.ts` is server-only and deliberately not in `@/lib/constants`.** `CONTEXT`, `URL` and
`DEPLOY_PRIME_URL` have no `NEXT_PUBLIC_` prefix, and `constants.ts` is imported by `CartContext`,
`WishlistContext` and the auth screens — putting it there would resolve every value to the localhost
fallback in the browser.

## Indexing

Production allows crawling; `deploy-preview` and `branch-deploy` get `Disallow: /` and **no**
`Sitemap:` line. `isIndexableDeploy()` fails **open** on an unrecognised `CONTEXT` — silently
de-indexing the real site is a failure nobody would notice until traffic vanished.

`robots.ts` keeps its own private-path list rather than importing the proxy's. They look like the
same list but answer different questions: `proxy.ts` is an enforced access boundary, robots.txt is a
request to well-behaved crawlers. Sharing one list would imply this file protects something.
(`/verify-email` is in ours but intentionally absent from the proxy's `AUTH_PAGES`.)

## Drive-by fix: `metadataBase`

It was hardcoded to `https://heybeautiful.com`, which **is not connected yet** (#18), so every
relative Open Graph image was resolving against a host that doesn't answer. Pointing it at the same
resolver fixes that and — the reason it belongs in this PR — stops the site carrying two disagreeing
base URLs.

## On `lastModified`

Omitted deliberately. `ShopifyProduct` has no date field of any kind, and the obvious substitute,
`new Date()`, would assert that every page changed every time the sitemap regenerates (hourly),
which teaches crawlers to discount the field. Adding a real `updatedAt` to the catalogue fragment is
a clean follow-up.

## Verification

`lint` · `typecheck` · `build` all pass. Beyond that, each case exercised against a running server:

| Case | Result |
| --- | --- |
| Default (local) | 2 static + 3 product URLs; robots lists all private paths |
| `CONTEXT=production` | Allows; sitemap + `Sitemap:` line use `URL` |
| `CONTEXT=deploy-preview` | `Disallow: /`, no `Sitemap:` line; sitemap uses `DEPLOY_PRIME_URL`, not `URL` |
| `NEXT_PUBLIC_SITE_URL` set | Overrides both; `og:image` picks up the same origin |
| Bad Shopify token | Degrades to the 2 static routes, HTTP 200, no crash |

Build output confirms `/sitemap.xml` carries the `1h` revalidate and the `products` tag, so the
existing Shopify webhook refreshes it, and its 3 product URLs match the 3 SSG routes exactly.

## Also in this diff

The `nextjs-agent-rules` block that `next dev` re-appends to `CLAUDE.md` on every run. Committing it
once stops it reappearing as an uncommitted change — which is what the block itself recommends.

## Still open on #14

Structured data (JSON-LD), `llm.txt`, per-product canonical + Open Graph, and a `favicon.ico`
(confirmed absent from `public/`).

Related: #96 adds the Search Console verification tag for the same issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0135pq3mk9wVb8YWb6EVzufp