### PR TITLE
feat: add JSON-LD structured data (#14)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,6 +228,23 @@ For non-feature work substitute the type segment: `fix`, `chore`, `refactor`, `d
   a list would imply robots.txt protects something. `sitemap.ts` must keep using the same
   `filter((p) => p.slug)` predicate as `generateStaticParams`, or it will advertise URLs that
   have no prerendered page.
+- **Structured data** (#14): schema.org payloads are built by pure functions in
+  `src/lib/structured-data.ts` and rendered by `src/components/JsonLd.tsx` — `Product` +
+  `BreadcrumbList` on `/store/[slug]`, `Organization` site-wide from `layout.tsx`.
+  **`JsonLd` escapes `<` to `<`, and that line is load-bearing** — Shopify descriptions are
+  merchant-controlled free text, so one containing `</script>` would otherwise close the tag early
+  and have the rest parsed as markup.
+  **The block is deliberately not nonced.** `proxy.ts` sets `script-src 'self' 'nonce-…'`, but a
+  script with a non-executable type is a *data block* — the HTML spec returns from "prepare the
+  script element" before the CSP inline check, so `script-src` never applies. Noncing it would mean
+  reading `headers()` in the page, which demotes the prerendered product routes to dynamic for no
+  benefit. Keep `/store/<handle>` showing as `●` in the build output.
+  **`aggregateRating` is gated on the development-catalogue flag.** `placeholder-products.ts`
+  hardcodes invented ratings, and publishing those is what earns a manual action for fake review
+  snippets — so ratings are only emitted when the real catalogue is in play. `brand` is hardcoded
+  for a related reason: Shopify's `vendor` is not fetched and reads "My Store" on most of the live
+  catalogue. Absolute URLs come from `absoluteUrl()`, which passes Shopify CDN URLs through
+  untouched.
 - **Page pattern**: a top-level route is a server `page.tsx` (`<Navbar /> … <Footer />` +
   `metadata`) that renders a `"use client"` `*Content.tsx` for interactivity (see
   `app/account`, `app/checkout`). Route protection lives in `src/proxy.ts` (Next 16 renamed the

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,8 @@ import { Cormorant_Garamond, Manrope } from "next/font/google";
 import "./globals.css";
 import { ClientWrapper } from "@/components/ClientWrapper";
 import { siteUrl } from "@/lib/site";
+import JsonLd from "@/components/JsonLd";
+import { organizationJsonLd } from "@/lib/structured-data";
 
 const cormorant = Cormorant_Garamond({
   subsets: ["latin"],
@@ -56,6 +58,8 @@ export default function RootLayout({
   return (
     <html lang="en" className={`${cormorant.variable} ${manrope.variable}`}>
       <body className="antialiased">
+        {/* Site-wide: the brand is the same on every page, product or not. */}
+        <JsonLd data={organizationJsonLd()} />
         <ClientWrapper>{children}</ClientWrapper>
       </body>
     </html>

--- a/src/app/store/[slug]/page.tsx
+++ b/src/app/store/[slug]/page.tsx
@@ -5,6 +5,8 @@ import Footer from "@/components/Footer";
 import { getProducts, getProductBySlug } from "@/lib/shopify";
 import { getRelatedProducts } from "@/lib/product";
 import ProductDetailContent from "./ProductDetailContent";
+import JsonLd from "@/components/JsonLd";
+import { breadcrumbJsonLd, productJsonLd } from "@/lib/structured-data";
 
 export async function generateStaticParams() {
   const products = await getProducts();
@@ -39,6 +41,15 @@ export default async function ProductPage({
 
   return (
     <main>
+      {/* Placeholders are the unconfigured-store "Coming Soon" tiles — nothing about
+          them is a real offer. They have no handle so they cannot reach this route,
+          but describing one to a search engine would be wrong if they ever did. */}
+      {!product.placeholder && (
+        <>
+          <JsonLd data={productJsonLd(product)} />
+          <JsonLd data={breadcrumbJsonLd(product)} />
+        </>
+      )}
       <Navbar />
       <ProductDetailContent product={product} related={related} />
       <Footer />

--- a/src/components/JsonLd.tsx
+++ b/src/components/JsonLd.tsx
@@ -1,0 +1,27 @@
+/**
+ * Renders a schema.org payload as JSON-LD (#14).
+ *
+ * Server-rendered on purpose — no `"use client"`. The payload has to be in the initial
+ * HTML, because that is what crawlers read; a client-rendered block would be invisible to
+ * most of them.
+ *
+ * NOT nonced, and deliberately so. `src/proxy.ts` sets `script-src 'self' 'nonce-…'`, but
+ * a script whose type is not an executable one is a *data block*: the HTML spec bails out
+ * of "prepare the script element" before the CSP inline check, so `script-src` never
+ * applies here. Noncing it would mean reading `headers()` in the pages that use it, which
+ * would demote the prerendered product routes to dynamic rendering for no benefit.
+ */
+export default function JsonLd({ data }: { data: object }) {
+  return (
+    <script
+      type="application/ld+json"
+      // Escaping `<` is load-bearing, not cosmetic. Product descriptions are
+      // merchant-controlled free text straight out of Shopify, so one containing
+      // `</script>` would otherwise close this tag early and have the rest of the
+      // payload parsed as markup. `<` is valid JSON and reads back as `<`.
+      dangerouslySetInnerHTML={{
+        __html: JSON.stringify(data).replace(/</g, "\\u003c"),
+      }}
+    />
+  );
+}

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -52,3 +52,16 @@ export function isIndexableDeploy(): boolean {
   const context = process.env.CONTEXT;
   return context === undefined || !PREVIEW_CONTEXTS.includes(context);
 }
+
+/**
+ * Turns a possibly-relative path into an absolute URL.
+ *
+ * schema.org rejects relative URLs, and `ShopifyProduct.image` is not consistently one
+ * thing: a real product carries a `https://cdn.shopify.com/…` URL, while the fallback and
+ * the whole development catalogue use site-relative paths like `/images/item-1.jpeg`. So
+ * anything already absolute passes through untouched.
+ */
+export function absoluteUrl(pathOrUrl: string): string {
+  if (/^https?:\/\//i.test(pathOrUrl)) return pathOrUrl;
+  return `${siteUrl()}/${pathOrUrl.replace(/^\/+/, "")}`;
+}

--- a/src/lib/structured-data.ts
+++ b/src/lib/structured-data.ts
@@ -1,0 +1,133 @@
+// schema.org JSON-LD builders (#14).
+//
+// Pure functions returning plain objects — no JSX and no I/O, so they can be exercised
+// from a scratch script without a render. Rendering is `@/components/JsonLd`, which owns
+// the escaping.
+
+import { defaultVariant, isSoldOut, type ShopifyProduct } from "@/lib/product";
+import { absoluteUrl, siteUrl } from "@/lib/site";
+
+const BRAND_NAME = "Hey Beautiful";
+
+/** Shopify sells in ZAR — the same currency `formatPrice` renders. */
+const CURRENCY = "ZAR";
+
+const IN_STOCK = "https://schema.org/InStock";
+const OUT_OF_STOCK = "https://schema.org/OutOfStock";
+
+/**
+ * Whether this build's rating data can be trusted enough to publish.
+ *
+ * The development catalogue (#68) hardcodes invented ratings — 4.9 from 128 reviews and
+ * so on — purely so card typography can be exercised. Every real product currently
+ * returns no review metafields at all. Emitting the invented numbers as `aggregateRating`
+ * is precisely what Google issues a manual action for, and those are slow to reverse, so
+ * ratings are only published when the real catalogue is the one being rendered.
+ */
+function ratingsAreReal(): boolean {
+  return process.env.NEXT_PUBLIC_USE_PLACEHOLDER_PRODUCTS !== "true";
+}
+
+function productUrl(product: ShopifyProduct): string {
+  return absoluteUrl(`/store/${product.slug ?? ""}`);
+}
+
+/**
+ * One `Offer` per variant, so a sold-out size is reported as sold out rather than being
+ * averaged away. A product with no variant data yields a single offer built from the
+ * product-level price.
+ */
+function buildOffers(product: ShopifyProduct) {
+  const url = productUrl(product);
+
+  const base = {
+    "@type": "Offer" as const,
+    url,
+    priceCurrency: CURRENCY,
+    itemCondition: "https://schema.org/NewCondition",
+  };
+
+  if (!product.variants?.length) {
+    return [
+      {
+        ...base,
+        price: product.price,
+        availability: isSoldOut(product) ? OUT_OF_STOCK : IN_STOCK,
+      },
+    ];
+  }
+
+  return product.variants.map((variant) => ({
+    ...base,
+    sku: variant.id,
+    name: variant.label,
+    price: variant.price,
+    availability: variant.availableForSale ? IN_STOCK : OUT_OF_STOCK,
+  }));
+}
+
+export function productJsonLd(product: ShopifyProduct) {
+  const images = (product.gallery?.length ? product.gallery : [product.image]).map(
+    absoluteUrl
+  );
+
+  const rating =
+    ratingsAreReal() && product.rating != null && product.reviews != null
+      ? {
+          aggregateRating: {
+            "@type": "AggregateRating",
+            ratingValue: product.rating,
+            reviewCount: product.reviews,
+          },
+        }
+      : {};
+
+  // `category` falls back to the literal "Product" when Shopify's productType is empty,
+  // which says nothing — omit it rather than assert a meaningless category.
+  const category =
+    product.category && product.category !== "Product"
+      ? { category: product.category }
+      : {};
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "Product",
+    name: product.name,
+    url: productUrl(product),
+    image: images,
+    ...(product.description ? { description: product.description } : {}),
+    // Shopify's `vendor` is not fetched and is inconsistent in the live store — two of
+    // three products report "My Store". The brand is not in doubt, so state it.
+    brand: { "@type": "Brand", name: BRAND_NAME },
+    ...(defaultVariant(product)?.id ? { sku: defaultVariant(product)!.id } : {}),
+    ...category,
+    offers: buildOffers(product),
+    ...rating,
+  };
+}
+
+export function breadcrumbJsonLd(product: ShopifyProduct) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "Home", item: absoluteUrl("/") },
+      { "@type": "ListItem", position: 2, name: "Store", item: absoluteUrl("/store") },
+      { "@type": "ListItem", position: 3, name: product.name, item: productUrl(product) },
+    ],
+  };
+}
+
+export function organizationJsonLd() {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    name: BRAND_NAME,
+    url: siteUrl(),
+    logo: absoluteUrl("/images/logo.jpeg"),
+    description:
+      "Premium feminine wellness supplements crafted for the modern woman. Performance meets femininity.",
+    // No `sameAs`: the site links to no social profiles, and inventing profile URLs would
+    // be worse than omitting the property.
+  };
+}


### PR DESCRIPTION
Adds the **Structured data** box on #14. Nothing in the site emitted schema.org markup, so a search
result could only ever be a plain blue link — this is what lets Google show price and availability
in the result itself.

| File | |
| --- | --- |
| `src/lib/structured-data.ts` | **new** — `productJsonLd`, `breadcrumbJsonLd`, `organizationJsonLd` |
| `src/components/JsonLd.tsx` | **new** — renders a payload, owns the escaping |
| `src/lib/site.ts` | adds `absoluteUrl()` |
| `src/app/store/[slug]/page.tsx` | Product + BreadcrumbList |
| `src/app/layout.tsx` | Organization, site-wide |
| `CLAUDE.md` | conventions entry |

## Three decisions worth reviewing

**1. `<` is escaped to `\u003c`, and that line is load-bearing.** Shopify descriptions are
merchant-controlled free text, so a description containing `</script>` would otherwise close the tag
early and have the rest of the payload parsed as markup. Verified against a hostile input
(`Glow </script><img src=x onerror=alert(1)>`): no raw `<` survives and the value round-trips
byte-for-byte through `JSON.parse`.

**2. The block is deliberately NOT nonced.** `proxy.ts` sets `script-src 'self' 'nonce-…'`, but a
script with a non-executable type is a *data block* — the HTML spec returns from "prepare the script
element" before the CSP inline check, so `script-src` never applies. Noncing it would mean reading
`headers()` in the page, which would demote the three prerendered product routes to dynamic
rendering for no benefit. The build output confirms they are still `●` (SSG).

**3. `aggregateRating` is gated on the development-catalogue flag.**
`src/lib/placeholder-products.ts` hardcodes invented ratings — 4.9 from 128 reviews, 4.8 from 94 —
while every real product currently returns `rating: null` and `ratingCount: null` from the
Storefront API. Netlify still has `NEXT_PUBLIC_USE_PLACEHOLDER_PRODUCTS=true`, so without this a
production build in that state would publish fabricated review counts, which is what Google issues
manual actions for. `brand` is hardcoded for a related reason: Shopify's `vendor` is not fetched and
reads **"My Store"** on two of the three live products.

Offers are emitted **one per variant**, so a sold-out size reports as sold out rather than being
averaged away.

## Verification

`lint` · `typecheck` · `build` pass, and the build still shows `/store/<handle>` as `●` (SSG).

Against the live Shopify catalogue, all three emitted blocks parse as valid JSON:

| Check | Result |
| --- | --- |
| `Product` on `/store/hey-beautiful-plant-protein` | name, `sku: 45578276012211`, `category: Supplements`, brand |
| Images | 4 URLs, all absolute |
| Offer | `100 ZAR`, `InStock` — matches the live variant |
| `aggregateRating` | **absent**, correctly — no review metafields exist |
| Breadcrumb | Home › Store › Hey Beautiful Plant Protein, absolute URLs |
| `/` and `/store` | `Organization` only, no stray `Product` |

**Guard test**, rebuilt with `NEXT_PUBLIC_USE_PLACEHOLDER_PRODUCTS=true` on a dev-catalogue product
that hardcodes 4.9/128: the rating renders visibly on the page, but `aggregateRating` is **absent**
from the markup, while `offers` still emits — and correctly, with per-variant availability
(`Trial · 14 servings` OutOfStock, `Full · 60 servings` InStock). That path is the only way to
exercise multi-variant offers, since every live product has a single Default Title variant.

**One thing I could not verify:** the *positive* `aggregateRating` path. It needs a real product
carrying `reviews.rating` metafields, and none exists in the store today. The guard's false branch is
proven; the true branch is the same expression but untested against real data.

Google's Rich Results Test needs a public URL, and Netlify credits are exhausted until September, so
that validation has to wait.

## Still open on #14

`llm.txt` is the last box. Also outstanding but separate: per-product `canonical` + Open Graph in
`generateMetadata`, and a `favicon.ico` (still absent from `public/`).

`hasMerchantReturnPolicy` and `shippingDetails` on Offer are deliberately out of scope — Google warns
without them, but both need real policy and shipping-rate data, which is the same Shopify admin work
that currently blocks a first order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0135pq3mk9wVb8YWb6EVzufp