### PR TITLE
feat: add llms.txt and explicit AI crawler rules (#14)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,7 +231,7 @@ For non-feature work substitute the type segment: `fix`, `chore`, `refactor`, `d
 - **Structured data** (#14): schema.org payloads are built by pure functions in
   `src/lib/structured-data.ts` and rendered by `src/components/JsonLd.tsx` — `Product` +
   `BreadcrumbList` on `/store/[slug]`, `Organization` site-wide from `layout.tsx`.
-  **`JsonLd` escapes `<` to `<`, and that line is load-bearing** — Shopify descriptions are
+  **`JsonLd` escapes `<` to `\u003c`, and that line is load-bearing** — Shopify descriptions are
   merchant-controlled free text, so one containing `</script>` would otherwise close the tag early
   and have the rest parsed as markup.
   **The block is deliberately not nonced.** `proxy.ts` sets `script-src 'self' 'nonce-…'`, but a
@@ -245,6 +245,16 @@ For non-feature work substitute the type segment: `fix`, `chore`, `refactor`, `d
   for a related reason: Shopify's `vendor` is not fetched and reads "My Store" on most of the live
   catalogue. Absolute URLs come from `absoluteUrl()`, which passes Shopify CDN URLs through
   untouched.
+- **`llms.txt` and AI crawlers** (#14): `src/app/llms.txt/route.ts` serves the llmstxt.org
+  convention — an H1, a blockquote summary, then annotated links. **The filename is plural**;
+  #14 calls it "llm.txt" but `llms.txt` is the name crawlers actually look for. It is a Route
+  Handler rather than a file in `public/` so the product list tracks Shopify, and it reuses
+  `getProducts()` to inherit the hourly revalidate and the `products` tag — a product webhook
+  refreshes it too. Keep it `○ (Static)` in the build output; it reads no request data.
+  `robots.ts` names the AI crawlers explicitly and **repeats `PRIVATE_PATHS` for that group**.
+  That repetition is load-bearing, not copy-paste: per the robots.txt spec a crawler obeys only
+  the most specific group matching its name and ignores `*` entirely, so naming GPTBot without
+  the disallows would *widen* its access to `/account` rather than leave it unchanged.
 - **Page pattern**: a top-level route is a server `page.tsx` (`<Navbar /> … <Footer />` +
   `metadata`) that renders a `"use client"` `*Content.tsx` for interactivity (see
   `app/account`, `app/checkout`). Route protection lives in `src/proxy.ts` (Next 16 renamed the

--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -1,0 +1,81 @@
+// /llms.txt — a curated, plain-text map of the store for AI assistants (#14).
+//
+// Follows the llmstxt.org convention: an H1, a blockquote summary, then H2 sections of
+// annotated links. The point is to hand a model the few things worth knowing in one cheap
+// fetch, instead of making it crawl and strip HTML to work out what this site sells.
+//
+// The filename is `llms.txt`, plural — that is the name the convention defines and the one
+// crawlers look for. Issue #14 writes it "llm.txt"; that is the same thing by a shorter name.
+//
+// This is a Route Handler rather than a static file in `public/` because the product list
+// has to track the Shopify catalogue. It reuses `getProducts()`, so it inherits the same
+// hourly revalidate and `products` cache tag as the storefront — a product webhook
+// refreshes this file too.
+
+import { getProducts } from "@/lib/shopify";
+import { isSoldOut, type ShopifyProduct } from "@/lib/product";
+import { formatPrice } from "@/lib/format";
+import { siteUrl } from "@/lib/site";
+
+// Prerendered at build and refreshed by the `products` tag, like sitemap.xml. Nothing here
+// reads the request, so there is no reason to render it per visitor.
+export const dynamic = "force-static";
+
+/** Shopify descriptions are long free text with newlines; a link annotation wants one line. */
+function summarise(text: string | undefined, max = 160): string {
+  if (!text) return "";
+  const flat = text.replace(/\s+/g, " ").trim();
+  return flat.length <= max ? flat : `${flat.slice(0, max - 1).trimEnd()}…`;
+}
+
+function productLine(product: ShopifyProduct, base: string): string {
+  const price = formatPrice(product.price);
+  const stock = isSoldOut(product) ? " Currently sold out." : "";
+  const summary = summarise(product.description);
+  // `category` falls back to the literal "Product" when Shopify's productType is empty,
+  // which tells a reader nothing — drop it rather than pad the line with a non-fact.
+  const category = product.category === "Product" ? "" : product.category;
+  const detail = [price, category, summary].filter(Boolean).join(" · ");
+
+  return `- [${product.name}](${base}/store/${product.slug}): ${detail}${stock}`;
+}
+
+export async function GET() {
+  const base = siteUrl();
+
+  // Same predicate as `generateStaticParams` and `sitemap.ts`: no handle, no detail page,
+  // so nothing to link to. It also excludes the "Coming Soon" placeholder tiles.
+  const products = (await getProducts()).filter((p) => p.slug);
+
+  const body = `# Hey Beautiful
+
+> Premium feminine wellness supplements for women — plant protein, collagen and daily
+> essentials. South African brand, prices in South African Rand (ZAR).
+
+Hey Beautiful is a direct-to-consumer wellness store. Browse the catalogue at ${base}/store;
+each product has its own page with variants, pricing and availability. Checkout is handled by
+Shopify, so orders, payment and delivery are managed there rather than on this site.
+
+## Products
+
+${products.length > 0 ? products.map((p) => productLine(p, base)).join("\n") : "- The catalogue is being updated. See " + base + "/store for the current range."}
+
+## Pages
+
+- [Home](${base}/): brand introduction, featured products and the story behind the range.
+- [Store](${base}/store): the full catalogue.
+
+## Notes
+
+- Prices are in ZAR and include the amount shown at checkout before shipping.
+- Availability is per variant — a product may have one size in stock and another sold out.
+- Account, cart and checkout pages require sign-in and are not useful to index.
+- This file is generated from the live catalogue and refreshes when products change.
+`;
+
+  return new Response(body, {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+    },
+  });
+}

--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -13,7 +13,7 @@
 // refreshes this file too.
 
 import { getProducts } from "@/lib/shopify";
-import { isSoldOut, type ShopifyProduct } from "@/lib/product";
+import { isSoldOut, meaningfulCategory, type ShopifyProduct } from "@/lib/product";
 import { formatPrice } from "@/lib/format";
 import { siteUrl } from "@/lib/site";
 
@@ -32,10 +32,9 @@ function productLine(product: ShopifyProduct, base: string): string {
   const price = formatPrice(product.price);
   const stock = isSoldOut(product) ? " Currently sold out." : "";
   const summary = summarise(product.description);
-  // `category` falls back to the literal "Product" when Shopify's productType is empty,
-  // which tells a reader nothing — drop it rather than pad the line with a non-fact.
-  const category = product.category === "Product" ? "" : product.category;
-  const detail = [price, category, summary].filter(Boolean).join(" · ");
+  const detail = [price, meaningfulCategory(product), summary]
+    .filter(Boolean)
+    .join(" · ");
 
   return `- [${product.name}](${base}/store/${product.slug}): ${detail}${stock}`;
 }

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -24,6 +24,34 @@ const PRIVATE_PATHS = [
   "/api/",
 ];
 
+/**
+ * AI crawlers, named explicitly so the policy is a decision rather than a side effect of
+ * the wildcard.
+ *
+ * The private paths are REPEATED for this group on purpose, and dropping them would be a
+ * real bug: per the robots.txt spec a crawler obeys only the most specific group matching
+ * its name and ignores `*` entirely. Naming GPTBot without repeating the disallows would
+ * therefore *widen* its access to /account and /checkout rather than leave it unchanged.
+ *
+ * Allowed because Hey Beautiful is a new brand with nothing proprietary on the site —
+ * being citable when someone asks an assistant for wellness supplements is free
+ * distribution. Flipping this to `disallow: "/"` is the only edit needed to reverse it.
+ */
+const AI_CRAWLERS = [
+  "GPTBot",
+  "OAI-SearchBot",
+  "ChatGPT-User",
+  "ClaudeBot",
+  "Claude-User",
+  "Claude-SearchBot",
+  "PerplexityBot",
+  "Perplexity-User",
+  "Google-Extended",
+  "Applebot-Extended",
+  "CCBot",
+  "meta-externalagent",
+];
+
 export default function robots(): MetadataRoute.Robots {
   // Deploy previews serve the entire site on a public URL. Left indexable they would
   // compete with production as duplicate content, so they are closed off wholesale — and
@@ -39,6 +67,11 @@ export default function robots(): MetadataRoute.Robots {
     rules: [
       {
         userAgent: "*",
+        allow: "/",
+        disallow: PRIVATE_PATHS,
+      },
+      {
+        userAgent: AI_CRAWLERS,
         allow: "/",
         disallow: PRIVATE_PATHS,
       },

--- a/src/lib/product.ts
+++ b/src/lib/product.ts
@@ -109,6 +109,20 @@ export function defaultVariant(
   );
 }
 
+/**
+ * The product's category, but only when it is a real one.
+ *
+ * `toProduct` substitutes the literal "Product" when Shopify's `productType` is empty —
+ * true for most of the live catalogue — and that value describes nothing. Callers that
+ * publish a category (JSON-LD, llms.txt) should omit it rather than assert a non-fact,
+ * so this returns undefined for the fallback.
+ */
+export function meaningfulCategory(product: ShopifyProduct): string | undefined {
+  return product.category && product.category !== "Product"
+    ? product.category
+    : undefined;
+}
+
 export function isSoldOut(product: ShopifyProduct): boolean {
   const variants = product.variants;
   // A product with no variant data (e.g. a placeholder) isn't "sold out".

--- a/src/lib/structured-data.ts
+++ b/src/lib/structured-data.ts
@@ -4,7 +4,12 @@
 // from a scratch script without a render. Rendering is `@/components/JsonLd`, which owns
 // the escaping.
 
-import { defaultVariant, isSoldOut, type ShopifyProduct } from "@/lib/product";
+import {
+  defaultVariant,
+  isSoldOut,
+  meaningfulCategory,
+  type ShopifyProduct,
+} from "@/lib/product";
 import { absoluteUrl, siteUrl } from "@/lib/site";
 
 const BRAND_NAME = "Hey Beautiful";
@@ -82,12 +87,8 @@ export function productJsonLd(product: ShopifyProduct) {
         }
       : {};
 
-  // `category` falls back to the literal "Product" when Shopify's productType is empty,
-  // which says nothing — omit it rather than assert a meaningless category.
-  const category =
-    product.category && product.category !== "Product"
-      ? { category: product.category }
-      : {};
+  const realCategory = meaningfulCategory(product);
+  const category = realCategory ? { category: realCategory } : {};
 
   return {
     "@context": "https://schema.org",


### PR DESCRIPTION
Closes the last box on **#14**.

## `/llms.txt`

Follows the [llmstxt.org](https://llmstxt.org/) convention — an H1, a blockquote summary, then H2
sections of annotated links — so an assistant can learn what this store sells in one cheap fetch
rather than crawling pages and stripping HTML.

**The filename is plural.** #14 writes it "llm.txt", but `llms.txt` is the name the convention
defines and the only one crawlers look for. Next's own docs ship at `/docs/llms.txt` for the same
reason.

It is a **Route Handler**, not a static file in `public/`, because the product list has to track the
Shopify catalogue. Reusing `getProducts()` means it inherits the hourly revalidate and the
`products` cache tag, so **the existing Shopify product webhook refreshes it** alongside the
sitemap. It reads nothing from the request, so it prerenders as static.

Product lines reuse `formatPrice` and the same `filter(p => p.slug)` predicate as `sitemap.ts` and
`generateStaticParams`, so the three can't drift.

## AI crawler rules

`robots.ts` now names the major AI crawlers and allows them. Hey Beautiful is a new brand with
nothing proprietary on the site, so being citable when someone asks an assistant for wellness
supplements is free distribution. Reversing it is a one-line change from `allow` to `disallow`.

**`PRIVATE_PATHS` is repeated for that group on purpose** — this is the part worth reviewing. Per
the robots.txt spec a crawler obeys only the *most specific* group matching its name and ignores `*`
entirely. Naming `GPTBot` without repeating the disallows would therefore **widen** its access to
`/account` and `/checkout` rather than leave it unchanged.

## Also

Drops the `category` fragment from product lines when it's the `"Product"` fallback — Shopify's
`productType` is empty on most of the live catalogue, so it padded the line without saying anything.
(#98 makes the same call for the `Product` schema; if both land, the check is worth unifying.)

## Verification

`lint` · `typecheck` · `build` pass. Build shows `/llms.txt` as **`○ (Static)` with `1h` revalidate**,
matching `sitemap.xml`.

| Check | Result |
| --- | --- |
| `GET /llms.txt` | 200, `Content-Type: text/plain; charset=utf-8` |
| Product lines | all 3 live products, prices via `formatPrice` (`R 300`, `R 210,99`, `R 100`) |
| `robots.txt` | AI group emitted with all 7 private paths repeated |
| Deploy-preview context | robots still `Disallow: /` with no AI group; llms.txt base URL follows `DEPLOY_PRIME_URL` |

## Two catalogue issues this surfaced (not code)

Both are visible in the generated file and will be visible to crawlers once live:

1. **"Test Product" (R 300, description "ABC") is an active, published product.** It appears in the
   sitemap, structured data and now llms.txt. Worth unpublishing before launch.
2. **"Glow Collagen Blend" has the wrong description** — it's a copy of the Plant Protein copy,
   describing 22g plant protein. Belongs with the content pass in #51.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0135pq3mk9wVb8YWb6EVzufp