### PR TITLE
feat: GA4 analytics behind Consent Mode v2 (#16)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,24 @@ NEXT_PUBLIC_SHOPIFY_STOREFRONT_TOKEN=
 # NEW BUILD; redeploying an existing one keeps the old value baked in.
 NEXT_PUBLIC_SITE_URL=
 
+# Google Analytics 4 measurement ID (#16), e.g. G-XXXXXXXXXX.
+# Google Analytics admin → Admin → Data streams → your web stream → Measurement ID.
+#
+# Optional. Unset means analytics is entirely inert: no script is loaded, no consent
+# banner is shown, and every tracking call is a no-op — so local development and deploy
+# previews do not pollute the property with test traffic.
+#
+# Consent Mode v2 is used: storage is DENIED by default and only upgraded if the visitor
+# accepts the banner, so this is safe for EU/UK visitors as well as POPIA.
+#
+# Note `purchase` is NOT tracked here. Checkout is handed off to Shopify, so the order is
+# created on Shopify's domain — configure the SAME measurement ID in the Shopify admin, or
+# the funnel stops at begin_checkout and conversions are never attributed.
+#
+# NEXT_PUBLIC_* values are inlined at BUILD time, so setting this in Netlify needs a NEW
+# BUILD; redeploying an existing one keeps the old value baked in.
+NEXT_PUBLIC_GA_MEASUREMENT_ID=
+
 # Development product catalogue (#68). Lets the storefront be built and reviewed
 # before the Shopify catalogue is populated.
 #

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,6 +245,25 @@ For non-feature work substitute the type segment: `fix`, `chore`, `refactor`, `d
   for a related reason: Shopify's `vendor` is not fetched and reads "My Store" on most of the live
   catalogue. Absolute URLs come from `absoluteUrl()`, which passes Shopify CDN URLs through
   untouched.
+- **Analytics** (#16): GA4 behind **Consent Mode v2**. `src/lib/analytics.ts` owns everything;
+  `NEXT_PUBLIC_GA_MEASUREMENT_ID` unset makes the whole thing inert (no script, no banner, every
+  call a no-op), so local and preview builds can't pollute the property.
+  **The consent default is queued by `push()`, not by a component.** It lived in `<Analytics>`'s
+  effect once and that was wrong: React runs child effects before parent ones, so a product page's
+  `view_item` fired *before* the consent default — a measurement command ahead of the consent
+  state Google requires to come first. Driving it from the first event of any kind makes the order
+  impossible to get wrong.
+  **No inline `<script>`.** Unlike the JSON-LD data blocks, an inline script really is subject to
+  `script-src`, so it would need the nonce, so the layout would need `headers()`, so every page
+  would go dynamic. `proxy.ts` needs **three** GA directives — `script-src` for gtag.js,
+  `connect-src` for the `/g/collect` beacons, `img-src` for the pixel fallback; missing the last
+  two is the classic "tag loads, no hits arrive".
+  **`purchase` is deliberately not tracked here** — checkout is Shopify's, so Shopify's own GA4
+  integration reports it against the same measurement ID. Our funnel ends at `begin_checkout`.
+  Cart events live in `CartContext` (the single choke point) and fire **outside** the state
+  updater, since StrictMode invokes updaters twice and would double-count.
+  `ConsentBanner` avoids `AnimatePresence` on purpose: its exit ran but never unmounted the node,
+  leaving an invisible fixed strip that swallowed clicks along the bottom of every page.
 - **Page pattern**: a top-level route is a server `page.tsx` (`<Navbar /> … <Footer />` +
   `metadata`) that renders a `"use client"` `*Content.tsx` for interactivity (see
   `app/account`, `app/checkout`). Route protection lives in `src/proxy.ts` (Next 16 renamed the

--- a/src/app/checkout/CheckoutContent.tsx
+++ b/src/app/checkout/CheckoutContent.tsx
@@ -9,6 +9,7 @@ import { Lock } from "lucide-react";
 import { fadeUp, staggerContainer } from "@/lib/motion";
 import { useAuth } from "@/context/AuthContext";
 import { useCart } from "@/context/CartContext";
+import { toAnalyticsItem, trackEcommerce } from "@/lib/analytics";
 import { formatPrice } from "@/lib/format";
 import { sessionExpiredLoginUrl, withFrom } from "@/lib/redirect";
 import { clearSessionHint } from "@/lib/session";
@@ -48,6 +49,14 @@ export default function CheckoutContent() {
     if (pending) return;
     setError("");
     setPending(true);
+
+    // Fired before the request, not after: this is the last event the funnel gets from us.
+    // Shopify owns everything past the redirect, so `purchase` is reported by Shopify's own
+    // GA4 integration against the same measurement ID — see `src/lib/analytics.ts`.
+    trackEcommerce(
+      "begin_checkout",
+      items.map((item) => toAnalyticsItem(item, item.quantity))
+    );
 
     try {
       const res = await fetch("/api/checkout", {

--- a/src/app/privacy/PrivacyContent.tsx
+++ b/src/app/privacy/PrivacyContent.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import Link from "next/link";
+import { motion } from "framer-motion";
+
+import { fadeUp, staggerContainer } from "@/lib/motion";
+
+/**
+ * Privacy policy (#16).
+ *
+ * ⚠️ DRAFT. Written to describe what this codebase actually does — every processor and
+ * storage key named below is real and can be checked against the source — but it has NOT
+ * been reviewed by anyone qualified to write binding legal copy. The visible notice at the
+ * top says so, and should be removed only once that review has happened.
+ *
+ * If the data flows change, this page changes with them. The ones it describes today:
+ *   - Firebase Auth       src/context/AuthContext.tsx
+ *   - localStorage keys   src/lib/constants.ts  (cart, wishlist)
+ *   - session hint cookie src/lib/constants.ts  (SESSION_HINT_COOKIE)
+ *   - analytics + consent src/lib/analytics.ts
+ *   - checkout handoff    src/app/api/checkout/route.ts
+ */
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <motion.section variants={fadeUp} className="mt-12 first:mt-0">
+      <h2 className="heading-serif text-ink mb-4 text-2xl">{title}</h2>
+      <div className="text-ink/70 space-y-4 text-sm leading-relaxed sm:text-base">
+        {children}
+      </div>
+    </motion.section>
+  );
+}
+
+export default function PrivacyContent() {
+  return (
+    <div className="section-py section-padding">
+      <motion.div
+        variants={staggerContainer}
+        initial="hidden"
+        animate="visible"
+        className="mx-auto max-w-3xl"
+      >
+        <motion.div variants={fadeUp}>
+          <p className="label-caps text-rose-dark">Legal</p>
+          <h1 className="heading-display text-ink mt-3 text-4xl sm:text-5xl">
+            Privacy Policy
+          </h1>
+          <p className="text-ink/50 mt-4 text-sm">Last updated 26 August 2026</p>
+        </motion.div>
+
+        <motion.div
+          variants={fadeUp}
+          className="glass-card border-rose-gold/30 mt-8 rounded-2xl border p-5"
+        >
+          <p className="text-ink/75 text-sm leading-relaxed">
+            <strong className="text-ink">Draft — pending review.</strong> This policy
+            accurately describes how the site currently works, but it has not yet been
+            reviewed by a legal professional. Please treat it as a working document rather
+            than a final statement of your rights, and{" "}
+            <Link
+              href="/account"
+              className="text-rose-dark underline underline-offset-4 hover:text-rose-gold"
+            >
+              contact us
+            </Link>{" "}
+            if anything here matters to a decision you are about to make.
+          </p>
+        </motion.div>
+
+        <Section title="Who we are">
+          <p>
+            Hey Beautiful is a South African online store selling wellness supplements. This
+            policy covers this website. It does not cover other companies&apos; websites we
+            link to.
+          </p>
+        </Section>
+
+        <Section title="What we collect">
+          <p>
+            <strong className="text-ink">If you create an account:</strong> your email
+            address, and your name if you provide one. If you sign in with Google or Apple,
+            we receive your email address and basic profile details from them. Accounts are
+            handled by Firebase Authentication, a Google service — we never see or store
+            your password.
+          </p>
+          <p>
+            <strong className="text-ink">If you shop:</strong> your bag and wishlist are
+            saved in your own browser&apos;s storage, on your device. They are not sent to
+            us until you begin checkout.
+          </p>
+          <p>
+            <strong className="text-ink">If you consent to analytics:</strong> pages you
+            visit, products you view, and actions such as adding to your bag. This is
+            collected by Google Analytics. Without your consent no analytics cookies are
+            set.
+          </p>
+          <p>
+            <strong className="text-ink">Automatically:</strong> your IP address is passed
+            to Shopify when your bag is turned into a checkout, so their systems can apply
+            rate limits fairly per shopper.
+          </p>
+        </Section>
+
+        <Section title="Payments and orders">
+          <p>
+            Checkout is handled entirely by <strong className="text-ink">Shopify</strong>.
+            When you proceed to payment you leave this site and continue on Shopify&apos;s
+            own secure checkout, where you enter your delivery and payment details. Card
+            processing is performed by our payment provider.
+          </p>
+          <p>
+            <strong className="text-ink">
+              We never see, handle or store your card details.
+            </strong>{" "}
+            Your order record, delivery address and payment information are held by Shopify
+            and the payment provider under their own privacy policies. If you were signed in,
+            your email address is passed to Shopify to save you retyping it.
+          </p>
+        </Section>
+
+        <Section title="Cookies and browser storage">
+          <p>We use as little as we can, and we tell you what each one is for.</p>
+          <ul className="mt-2 space-y-2 pl-5">
+            <li className="list-disc">
+              <strong className="text-ink">Essential.</strong> A small marker that records
+              you are signed in, so pages know whether to show your account. Your bag and
+              wishlist are stored the same way. These are required for the site to work and
+              cannot be turned off.
+            </li>
+            <li className="list-disc">
+              <strong className="text-ink">Analytics.</strong> Set by Google Analytics{" "}
+              <strong className="text-ink">only after you accept</strong>. Decline, and no
+              analytics cookies are stored — we receive only an anonymous, cookie-free signal
+              that a page was viewed.
+            </li>
+          </ul>
+          <p>
+            You can change your mind at any time by clearing this site&apos;s data in your
+            browser settings, which will make the consent banner appear again.
+          </p>
+        </Section>
+
+        <Section title="Who we share it with">
+          <p>
+            We do not sell your personal information. We share it only with the services
+            that make the store work:
+          </p>
+          <ul className="mt-2 space-y-2 pl-5">
+            <li className="list-disc">
+              <strong className="text-ink">Google (Firebase)</strong> — accounts and sign-in
+            </li>
+            <li className="list-disc">
+              <strong className="text-ink">Google Analytics</strong> — usage analytics, only
+              with your consent
+            </li>
+            <li className="list-disc">
+              <strong className="text-ink">Shopify</strong> — checkout, orders and delivery
+            </li>
+            <li className="list-disc">
+              <strong className="text-ink">Our payment provider</strong> — card and EFT
+              payments
+            </li>
+          </ul>
+          <p>
+            Some of these process data outside South Africa. They are established providers
+            with their own data-protection commitments.
+          </p>
+        </Section>
+
+        <Section title="Your rights">
+          <p>
+            Under the Protection of Personal Information Act (POPIA) you may ask us to show
+            you what personal information we hold about you, correct it if it is wrong,
+            delete it, or stop using it for a particular purpose. You may also object to
+            processing and complain to the Information Regulator of South Africa.
+          </p>
+          <p>
+            You can delete your account at any time from your{" "}
+            <Link
+              href="/account"
+              className="text-rose-dark underline underline-offset-4 hover:text-rose-gold"
+            >
+              account page
+            </Link>
+            . Order records held by Shopify may be retained where the law requires it, for
+            example for tax purposes.
+          </p>
+        </Section>
+
+        <Section title="Changes to this policy">
+          <p>
+            If we change how we handle your information, we will update this page and the
+            date at the top.
+          </p>
+        </Section>
+      </motion.div>
+    </div>
+  );
+}

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+
+import Navbar from "@/components/Navbar";
+import Footer from "@/components/Footer";
+import PrivacyContent from "./PrivacyContent";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy — Hey Beautiful",
+  description:
+    "How Hey Beautiful collects, uses and stores your personal information, and the choices you have.",
+};
+
+export default function PrivacyPage() {
+  return (
+    <main>
+      <Navbar />
+      <PrivacyContent />
+      <Footer />
+    </main>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -20,6 +20,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const staticRoutes: MetadataRoute.Sitemap = [
     { url: `${base}/`, changeFrequency: "weekly", priority: 1 },
     { url: `${base}/store`, changeFrequency: "daily", priority: 0.9 },
+    { url: `${base}/privacy`, changeFrequency: "yearly", priority: 0.2 },
   ];
 
   // `getProducts` never throws: it returns [] for a configured store that errored, and the

--- a/src/app/store/StoreContent.tsx
+++ b/src/app/store/StoreContent.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { motion, useInView, useReducedMotion } from "framer-motion";
 import { fadeUp, staggerContainer } from "@/lib/motion";
 import { bundles } from "@/lib/products";
-import { getShowcaseProducts, type ShopifyProduct } from "@/lib/product";
+import { getShowcaseProducts, toCartItem, type ShopifyProduct } from "@/lib/product";
+import { toAnalyticsItem, trackEcommerce } from "@/lib/analytics";
 import BundleCard from "@/components/BundleCard";
 import BrandStory from "@/components/sections/BrandStory";
 import { NAVBAR_ID } from "@/components/Navbar";
@@ -26,6 +27,17 @@ const SCROLL_GAP = 16;
  * `FeaturedShowcase` is a curated shelf and stays put — see the note in that file.
  */
 export default function StoreContent({ products }: { products: ShopifyProduct[] }) {
+  // One list impression per visit. Capped because GA4 rejects oversized payloads and the
+  // first screenful is what the shopper actually saw.
+  useEffect(() => {
+    if (products.length === 0) return;
+    trackEcommerce(
+      "view_item_list",
+      products.slice(0, 20).map((p) => toAnalyticsItem(toCartItem(p))),
+      { item_list_name: "Store" }
+    );
+  }, [products]);
+
   const reducedMotion = useReducedMotion();
   const [activeCategory, setActiveCategory] = useState<string>(ALL_CATEGORIES);
   const bundlesRef = useRef<HTMLDivElement>(null);

--- a/src/app/store/[slug]/ProductDetailContent.tsx
+++ b/src/app/store/[slug]/ProductDetailContent.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Image from "next/image";
 import { motion } from "framer-motion";
 import { Star, ShoppingBag, Heart, Check } from "lucide-react";
@@ -11,6 +11,7 @@ import { useCart } from "@/context/CartContext";
 import { useWishlist } from "@/context/WishlistContext";
 import ShopifyProductCard from "@/components/ShopifyProductCard";
 import { defaultVariant, isSoldOut, toCartItem, type ShopifyProduct } from "@/lib/product";
+import { toAnalyticsItem, trackEcommerce } from "@/lib/analytics";
 
 function Stars({ rating, size = 13 }: { rating: number; size?: number }) {
   return (
@@ -43,6 +44,14 @@ export default function ProductDetailContent({
   const [activeImage, setActiveImage] = useState(gallery[0]);
   const [variant, setVariant] = useState(() => defaultVariant(product));
   const [added, setAdded] = useState(false);
+
+  // One impression per product. Deliberately not keyed on `variant`: switching size is not
+  // a new product view, and GA4 would read the repeats as separate visits to the page.
+  useEffect(() => {
+    trackEcommerce("view_item", [
+      toAnalyticsItem(toCartItem(product, defaultVariant(product)), 1),
+    ]);
+  }, [product]);
 
   const { addItem } = useCart();
   const { toggleItem, isWishlisted } = useWishlist();

--- a/src/components/Analytics.tsx
+++ b/src/components/Analytics.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import Script from "next/script";
+import { usePathname } from "next/navigation";
+
+import {
+  GA_MEASUREMENT_ID,
+  isAnalyticsConfigured,
+  readStoredConsent,
+  trackPageView,
+} from "@/lib/analytics";
+
+/**
+ * Loads GA4 under Consent Mode v2 (#16).
+ *
+ * WHY THE BOOTSTRAP IS JAVASCRIPT AND NOT AN INLINE <script>:
+ * Google's snippet is normally an inline script, and an inline script — unlike the JSON-LD
+ * data blocks — really is subject to `script-src`, so under `proxy.ts`'s policy it would
+ * need the per-request nonce. Reading that nonce means calling `headers()` in the layout,
+ * which would make EVERY page dynamic and cost the prerendered product routes their SSG.
+ * Pushing to `dataLayer` from this client component instead is same-origin code, allowed
+ * by `'self'` with no nonce and no dynamic rendering.
+ *
+ * ORDERING IS SAFE EITHER WAY. `dataLayer` is a queue and gtag.js does nothing until it
+ * sees a `config` command, so whether the script or this effect wins the race, the consent
+ * default is processed before the config that follows it in the same queue.
+ */
+export default function Analytics() {
+  const pathname = usePathname();
+  const bootstrapped = useRef(false);
+
+  useEffect(() => {
+    if (!isAnalyticsConfigured() || bootstrapped.current) return;
+    bootstrapped.current = true;
+
+    window.dataLayer = window.dataLayer ?? [];
+
+    // Denied BEFORE anything else. Under Consent Mode v2 this still yields cookieless
+    // pings, so traffic shape survives a visitor who never answers the banner.
+    window.dataLayer.push([
+      "consent",
+      "default",
+      {
+        analytics_storage: "denied",
+        ad_storage: "denied",
+        ad_user_data: "denied",
+        ad_personalization: "denied",
+      },
+    ]);
+
+    // A returning visitor who already accepted shouldn't spend a page view in the denied
+    // state, so their stored answer is replayed before the first config.
+    const stored = readStoredConsent();
+    if (stored === "granted") {
+      window.dataLayer.push([
+        "consent",
+        "update",
+        { analytics_storage: "granted" },
+      ]);
+    }
+
+    window.dataLayer.push(["js", new Date()]);
+    // `send_page_view: false` because this is a single-page app: gtag would only ever see
+    // the first load, so page views are sent explicitly below and would otherwise double
+    // count the landing page.
+    window.dataLayer.push([
+      "config",
+      GA_MEASUREMENT_ID,
+      { send_page_view: false },
+    ]);
+  }, []);
+
+  // Fires for the landing page and every client-side navigation after it.
+  useEffect(() => {
+    if (!isAnalyticsConfigured() || !pathname) return;
+    trackPageView(pathname);
+  }, [pathname]);
+
+  if (!isAnalyticsConfigured()) return null;
+
+  return (
+    <Script
+      src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
+      strategy="afterInteractive"
+    />
+  );
+}

--- a/src/components/Analytics.tsx
+++ b/src/components/Analytics.tsx
@@ -1,77 +1,35 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import Script from "next/script";
 import { usePathname } from "next/navigation";
 
 import {
   GA_MEASUREMENT_ID,
   isAnalyticsConfigured,
-  readStoredConsent,
   trackPageView,
 } from "@/lib/analytics";
 
 /**
- * Loads GA4 under Consent Mode v2 (#16).
+ * Loads gtag.js and reports client-side navigations (#16).
  *
- * WHY THE BOOTSTRAP IS JAVASCRIPT AND NOT AN INLINE <script>:
- * Google's snippet is normally an inline script, and an inline script — unlike the JSON-LD
- * data blocks — really is subject to `script-src`, so under `proxy.ts`'s policy it would
- * need the per-request nonce. Reading that nonce means calling `headers()` in the layout,
- * which would make EVERY page dynamic and cost the prerendered product routes their SSG.
- * Pushing to `dataLayer` from this client component instead is same-origin code, allowed
- * by `'self'` with no nonce and no dynamic rendering.
+ * The consent bootstrap deliberately does NOT live here. It used to, and effect order made
+ * it wrong: React runs child effects before parent ones, so a product page's `view_item`
+ * fired before this component had pushed anything, putting a measurement command ahead of
+ * the consent default. It now lives in `@/lib/analytics`, triggered by the first event of
+ * any kind, which makes the ordering impossible to get wrong.
  *
- * ORDERING IS SAFE EITHER WAY. `dataLayer` is a queue and gtag.js does nothing until it
- * sees a `config` command, so whether the script or this effect wins the race, the consent
- * default is processed before the config that follows it in the same queue.
+ * WHY THERE IS NO INLINE <script>: Google's snippet is normally inline, and an inline
+ * script — unlike the JSON-LD data blocks from #14 — really is subject to `script-src`, so
+ * under `proxy.ts`'s policy it would need the per-request nonce. Reading that nonce means
+ * calling `headers()` in the layout, which would make every page dynamic and cost the
+ * prerendered product routes their SSG. Same-origin client code needs neither.
  */
 export default function Analytics() {
   const pathname = usePathname();
-  const bootstrapped = useRef(false);
 
-  useEffect(() => {
-    if (!isAnalyticsConfigured() || bootstrapped.current) return;
-    bootstrapped.current = true;
-
-    window.dataLayer = window.dataLayer ?? [];
-
-    // Denied BEFORE anything else. Under Consent Mode v2 this still yields cookieless
-    // pings, so traffic shape survives a visitor who never answers the banner.
-    window.dataLayer.push([
-      "consent",
-      "default",
-      {
-        analytics_storage: "denied",
-        ad_storage: "denied",
-        ad_user_data: "denied",
-        ad_personalization: "denied",
-      },
-    ]);
-
-    // A returning visitor who already accepted shouldn't spend a page view in the denied
-    // state, so their stored answer is replayed before the first config.
-    const stored = readStoredConsent();
-    if (stored === "granted") {
-      window.dataLayer.push([
-        "consent",
-        "update",
-        { analytics_storage: "granted" },
-      ]);
-    }
-
-    window.dataLayer.push(["js", new Date()]);
-    // `send_page_view: false` because this is a single-page app: gtag would only ever see
-    // the first load, so page views are sent explicitly below and would otherwise double
-    // count the landing page.
-    window.dataLayer.push([
-      "config",
-      GA_MEASUREMENT_ID,
-      { send_page_view: false },
-    ]);
-  }, []);
-
-  // Fires for the landing page and every client-side navigation after it.
+  // Fires for the landing page and every client-side navigation after it. gtag.js is
+  // configured with `send_page_view: false`, so this is the only source of page views.
   useEffect(() => {
     if (!isAnalyticsConfigured() || !pathname) return;
     trackPageView(pathname);

--- a/src/components/ClientWrapper.tsx
+++ b/src/components/ClientWrapper.tsx
@@ -6,6 +6,8 @@ import { WishlistProvider } from "@/context/WishlistContext";
 import WishlistSidebar from "@/components/WishlistSidebar";
 import CartSidebar from "@/components/CartSidebar";
 import CartNotification from "@/components/CartNotification";
+import Analytics from "@/components/Analytics";
+import ConsentBanner from "@/components/ConsentBanner";
 import type { ReactNode } from "react";
 
 export function ClientWrapper({ children }: { children: ReactNode }) {
@@ -17,6 +19,8 @@ export function ClientWrapper({ children }: { children: ReactNode }) {
           <WishlistSidebar />
           <CartSidebar />
           <CartNotification />
+          <Analytics />
+          <ConsentBanner />
         </WishlistProvider>
       </CartProvider>
     </AuthProvider>

--- a/src/components/ConsentBanner.tsx
+++ b/src/components/ConsentBanner.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useSyncExternalStore } from "react";
+import { useState, useSyncExternalStore } from "react";
 import Link from "next/link";
-import { AnimatePresence, motion } from "framer-motion";
+import { motion } from "framer-motion";
 
 import { ease } from "@/lib/motion";
 import {
@@ -25,6 +25,13 @@ import {
  * state. `localStorage` is exactly the "external store" that hook exists for, and its
  * server snapshot ("unknown") lets the server render nothing instead of guessing — so a
  * visitor who already answered never sees the banner flash before it disappears.
+ *
+ * NO `AnimatePresence`, deliberately, even though `SideDrawer` uses it for the same shape
+ * of thing. An exit animation here ran to completion and then never unmounted the node,
+ * leaving an invisible `position: fixed` strip across the bottom of every page that
+ * intercepted clicks — confirmed with `elementFromPoint`, and reproducible in a production
+ * build with and without a `key`. A banner that vanishes instantly costs far less than one
+ * that silently breaks the footer, so this animates in and then simply stops rendering.
  */
 export default function ConsentBanner() {
   const consent = useSyncExternalStore(
@@ -33,58 +40,58 @@ export default function ConsentBanner() {
     getConsentServerSnapshot
   );
 
+  // Dismissal is ordinary React state so the component unmounts on the normal render path.
+  // The store still supplies the INITIAL answer, which is what keeps hydration honest.
+  const [dismissed, setDismissed] = useState(false);
+
   const answer = (choice: ConsentChoice) => {
     storeConsent(choice);
     updateConsent(choice);
+    setDismissed(true);
   };
 
-  const visible = isAnalyticsConfigured() && consent === "pending";
+  if (!isAnalyticsConfigured() || consent !== "pending" || dismissed) return null;
 
   return (
-    <AnimatePresence>
-      {visible && (
-        <motion.div
-          initial={{ opacity: 0, y: 24 }}
-          animate={{ opacity: 1, y: 0 }}
-          exit={{ opacity: 0, y: 24 }}
-          transition={{ duration: 0.6, ease: ease.cinematic }}
-          className="fixed inset-x-0 bottom-0 z-50 section-padding pb-6 pt-4"
-          role="dialog"
-          aria-live="polite"
-          aria-label="Analytics cookies"
-        >
-          <div className="glass-card mx-auto flex max-w-4xl flex-col gap-4 rounded-2xl p-5 sm:flex-row sm:items-center sm:justify-between sm:gap-6">
-            <p className="text-ink/75 text-sm leading-relaxed">
-              We use analytics cookies to understand how the store is used, so we can make
-              it better. Nothing is stored until you say yes.{" "}
-              <Link
-                href="/privacy"
-                className="text-rose-dark underline underline-offset-4 transition-colors duration-300 hover:text-rose-gold"
-              >
-                Read our privacy policy
-              </Link>
-              .
-            </p>
+    <motion.div
+      initial={{ opacity: 0, y: 24 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.6, ease: ease.cinematic }}
+      className="fixed inset-x-0 bottom-0 z-50 section-padding pb-6 pt-4"
+      role="dialog"
+      aria-live="polite"
+      aria-label="Analytics cookies"
+    >
+      <div className="glass-card mx-auto flex max-w-4xl flex-col gap-4 rounded-2xl p-5 sm:flex-row sm:items-center sm:justify-between sm:gap-6">
+        <p className="text-ink/75 text-sm leading-relaxed">
+          We use analytics cookies to understand how the store is used, so we can make it
+          better. Nothing is stored until you say yes.{" "}
+          <Link
+            href="/privacy"
+            className="text-rose-dark underline underline-offset-4 transition-colors duration-300 hover:text-rose-gold"
+          >
+            Read our privacy policy
+          </Link>
+          .
+        </p>
 
-            <div className="flex shrink-0 gap-3">
-              <button
-                type="button"
-                onClick={() => answer("denied")}
-                className="btn-luxury btn-outline px-5 py-2.5 text-xs"
-              >
-                Decline
-              </button>
-              <button
-                type="button"
-                onClick={() => answer("granted")}
-                className="btn-luxury btn-primary px-5 py-2.5 text-xs"
-              >
-                Accept
-              </button>
-            </div>
-          </div>
-        </motion.div>
-      )}
-    </AnimatePresence>
+        <div className="flex shrink-0 gap-3">
+          <button
+            type="button"
+            onClick={() => answer("denied")}
+            className="btn-luxury btn-outline px-5 py-2.5 text-xs"
+          >
+            Decline
+          </button>
+          <button
+            type="button"
+            onClick={() => answer("granted")}
+            className="btn-luxury btn-primary px-5 py-2.5 text-xs"
+          >
+            Accept
+          </button>
+        </div>
+      </div>
+    </motion.div>
   );
 }

--- a/src/components/ConsentBanner.tsx
+++ b/src/components/ConsentBanner.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+import Link from "next/link";
+import { AnimatePresence, motion } from "framer-motion";
+
+import { ease } from "@/lib/motion";
+import {
+  getConsentServerSnapshot,
+  getConsentSnapshot,
+  isAnalyticsConfigured,
+  storeConsent,
+  subscribeConsent,
+  updateConsent,
+  type ConsentChoice,
+} from "@/lib/analytics";
+
+/**
+ * Asks once, remembers the answer (#16).
+ *
+ * Only rendered when analytics is actually configured — with no measurement ID there is
+ * nothing to consent to, and asking anyway would be theatre.
+ *
+ * The stored answer is read through `useSyncExternalStore` rather than an effect that sets
+ * state. `localStorage` is exactly the "external store" that hook exists for, and its
+ * server snapshot ("unknown") lets the server render nothing instead of guessing — so a
+ * visitor who already answered never sees the banner flash before it disappears.
+ */
+export default function ConsentBanner() {
+  const consent = useSyncExternalStore(
+    subscribeConsent,
+    getConsentSnapshot,
+    getConsentServerSnapshot
+  );
+
+  const answer = (choice: ConsentChoice) => {
+    storeConsent(choice);
+    updateConsent(choice);
+  };
+
+  const visible = isAnalyticsConfigured() && consent === "pending";
+
+  return (
+    <AnimatePresence>
+      {visible && (
+        <motion.div
+          initial={{ opacity: 0, y: 24 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: 24 }}
+          transition={{ duration: 0.6, ease: ease.cinematic }}
+          className="fixed inset-x-0 bottom-0 z-50 section-padding pb-6 pt-4"
+          role="dialog"
+          aria-live="polite"
+          aria-label="Analytics cookies"
+        >
+          <div className="glass-card mx-auto flex max-w-4xl flex-col gap-4 rounded-2xl p-5 sm:flex-row sm:items-center sm:justify-between sm:gap-6">
+            <p className="text-ink/75 text-sm leading-relaxed">
+              We use analytics cookies to understand how the store is used, so we can make
+              it better. Nothing is stored until you say yes.{" "}
+              <Link
+                href="/privacy"
+                className="text-rose-dark underline underline-offset-4 transition-colors duration-300 hover:text-rose-gold"
+              >
+                Read our privacy policy
+              </Link>
+              .
+            </p>
+
+            <div className="flex shrink-0 gap-3">
+              <button
+                type="button"
+                onClick={() => answer("denied")}
+                className="btn-luxury btn-outline px-5 py-2.5 text-xs"
+              >
+                Decline
+              </button>
+              <button
+                type="button"
+                onClick={() => answer("granted")}
+                className="btn-luxury btn-primary px-5 py-2.5 text-xs"
+              >
+                Accept
+              </button>
+            </div>
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -145,10 +145,17 @@ export default function Footer() {
                 © {new Date().getFullYear()} Hey Beautiful. All rights reserved.
               </p>
               <div className="flex gap-4">
-                {["Privacy Policy", "Terms", "Accessibility"].map((label) => (
+                {/* Only Privacy Policy exists so far. Terms and Accessibility are still
+                    `#` placeholders — tracked separately rather than linked to nothing
+                    that looks real. */}
+                {[
+                  { label: "Privacy Policy", href: "/privacy" },
+                  { label: "Terms", href: "#" },
+                  { label: "Accessibility", href: "#" },
+                ].map(({ label, href }) => (
                   <Link
                     key={label}
-                    href="#"
+                    href={href}
                     className="text-white/25 hover:text-white/50 text-xs transition-colors duration-300"
                   >
                     {label}

--- a/src/context/CartContext.tsx
+++ b/src/context/CartContext.tsx
@@ -10,6 +10,7 @@ import {
   type ReactNode,
 } from "react";
 
+import { toAnalyticsItem, trackEcommerce } from "@/lib/analytics";
 import { CART_STORAGE_KEY as STORAGE_KEY, MAX_CART_QUANTITY } from "@/lib/constants";
 
 export interface CartProduct {
@@ -105,6 +106,10 @@ export function CartProvider({ children }: { children: ReactNode }) {
   }, [items, loaded]);
 
   const addItem = useCallback((product: Omit<CartProduct, "quantity">) => {
+    // Fired outside the state updater on purpose: React may invoke an updater twice in
+    // development StrictMode, which would double-count the event.
+    trackEcommerce("add_to_cart", [toAnalyticsItem(product, 1)]);
+
     setItems((prev) => {
       const existing = prev.find((p) => p.id === product.id);
       if (existing) {
@@ -119,20 +124,39 @@ export function CartProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const removeItem = useCallback((id: string) => {
+    const going = items.find((p) => p.id === id);
+    if (going) {
+      trackEcommerce("remove_from_cart", [
+        toAnalyticsItem(going, going.quantity),
+      ]);
+    }
     setItems((prev) => prev.filter((p) => p.id !== id));
-  }, []);
+    // `items` in the deps is free here: the provider's value is an inline object, so it is
+    // rebuilt on every render anyway and no consumer was relying on a stable identity.
+  }, [items]);
 
   const updateQuantity = useCallback((id: string, quantity: number) => {
     // Clamped to the same ceiling the checkout endpoint enforces (#31), so the
     // control simply stops rather than letting a shopper build a bag that is
     // rejected at the last step.
     const capped = Math.min(quantity, MAX_CART_QUANTITY);
+
+    // Stepping a line down to zero is a removal, and reads as one in the funnel.
+    if (capped <= 0) {
+      const going = items.find((p) => p.id === id);
+      if (going) {
+        trackEcommerce("remove_from_cart", [
+          toAnalyticsItem(going, going.quantity),
+        ]);
+      }
+    }
+
     setItems((prev) =>
       capped <= 0
         ? prev.filter((p) => p.id !== id)
         : prev.map((p) => (p.id === id ? { ...p, quantity: capped } : p))
     );
-  }, []);
+  }, [items]);
 
   const isInCart = useCallback(
     (id: string) => items.some((p) => p.id === id),

--- a/src/context/WishlistContext.tsx
+++ b/src/context/WishlistContext.tsx
@@ -8,6 +8,7 @@ import {
   type ReactNode,
 } from "react";
 
+import { toAnalyticsItem, trackEcommerce } from "@/lib/analytics";
 import { WISHLIST_STORAGE_KEY as STORAGE_KEY } from "@/lib/constants";
 import type { CartLine } from "@/lib/product";
 
@@ -116,6 +117,12 @@ export function WishlistProvider({ children }: { children: ReactNode }) {
   }, [items, loaded]);
 
   const toggleItem = (product: WishlistProduct) => {
+    // Only the add direction is an event. GA4 has no `remove_from_wishlist`, and inventing
+    // a custom one would sit outside the standard ecommerce reports where it is useless.
+    if (!items.some((p) => p.id === product.id)) {
+      trackEcommerce("add_to_wishlist", [toAnalyticsItem(product)]);
+    }
+
     setItems((prev) =>
       prev.some((p) => p.id === product.id)
         ? prev.filter((p) => p.id !== product.id)

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -31,18 +31,61 @@ declare global {
 }
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
+let bootstrapped = false;
+
+/**
+ * Queues the consent default, then the config, exactly once.
+ *
+ * This lives here rather than in a component effect because effect order made it wrong:
+ * React runs child effects before parent ones, so the product page's `view_item` fired
+ * before `<Analytics>` had pushed anything — putting a measurement command ahead of the
+ * consent default, which Google explicitly requires to come first. Driving it from `push`
+ * makes the order impossible to get wrong: whatever fires first triggers the bootstrap
+ * ahead of itself.
+ */
+function bootstrap(): void {
+  if (bootstrapped) return;
+  bootstrapped = true;
+
+  window.dataLayer = window.dataLayer ?? [];
+
+  // Denied before anything else. Under Consent Mode v2 this still yields cookieless pings,
+  // so traffic shape survives a visitor who never answers the banner.
+  window.dataLayer.push([
+    "consent",
+    "default",
+    {
+      analytics_storage: "denied",
+      ad_storage: "denied",
+      ad_user_data: "denied",
+      ad_personalization: "denied",
+    },
+  ]);
+
+  // A returning visitor who already accepted shouldn't spend a page view denied.
+  if (readStoredConsent() === "granted") {
+    window.dataLayer.push(["consent", "update", { analytics_storage: "granted" }]);
+  }
+
+  window.dataLayer.push(["js", new Date()]);
+  // `send_page_view: false` because this is a single-page app: gtag.js only ever sees the
+  // first load, so page views are sent explicitly and would otherwise double count the
+  // landing page.
+  window.dataLayer.push(["config", GA_MEASUREMENT_ID, { send_page_view: false }]);
+}
+
 /**
  * Pushes to `dataLayer` directly rather than calling `window.gtag`.
  *
- * The two are equivalent once gtag.js has loaded, but events fired before it finishes
- * loading would be dropped by a `window.gtag` call that isn't defined yet. `dataLayer` is
- * created synchronously by the consent bootstrap, so anything queued on it is replayed
- * when the script arrives — which matters for `view_item`, fired on first paint.
+ * The two are equivalent once gtag.js has loaded, but an event fired before it finishes
+ * loading would be dropped by a `window.gtag` that isn't defined yet. `dataLayer` is a
+ * plain array, so anything queued on it is replayed when the script arrives — which
+ * matters for `view_item`, fired on first paint.
  */
 function push(...args: GtagArgs): void {
   if (typeof window === "undefined" || !isAnalyticsConfigured()) return;
-  window.dataLayer = window.dataLayer ?? [];
-  window.dataLayer.push(args);
+  bootstrap();
+  window.dataLayer!.push(args);
 }
 
 /** The visitor's stored choice, or null if they haven't answered yet. */
@@ -129,6 +172,39 @@ export interface AnalyticsItem {
   quantity?: number;
 }
 
+/**
+ * Maps a cart line or product to GA4's item shape.
+ *
+ * Structurally typed rather than importing `CartLine`, so this module stays independent of
+ * the product model. `item_id` prefers the Shopify variant id because that is the actual
+ * SKU — the thing a merchandiser can look up — falling back to the namespaced cart key for
+ * lines that have no variant.
+ */
+export function toAnalyticsItem(
+  line: {
+    id: string;
+    name: string;
+    category: string;
+    price: number;
+    variantId?: string | null;
+  },
+  quantity?: number
+): AnalyticsItem {
+  // "Product" is what `toProduct` substitutes for an empty Shopify productType, and
+  // shipping it would fill GA4's category dimension with a word that distinguishes nothing.
+  // The JSON-LD builder makes the same call; PR #99 extracts both onto a shared
+  // `meaningfulCategory()` helper, which this should collapse onto once that lands.
+  const category = line.category !== "Product" ? line.category : undefined;
+
+  return {
+    item_id: line.variantId ?? line.id,
+    item_name: line.name,
+    price: line.price,
+    ...(category ? { item_category: category } : {}),
+    ...(quantity !== undefined ? { quantity } : {}),
+  };
+}
+
 type EcommerceEvent =
   | "view_item"
   | "view_item_list"
@@ -147,6 +223,9 @@ export function trackEcommerce(
   items: AnalyticsItem[],
   extra?: Record<string, unknown>
 ): void {
+  // A list impression has no monetary value — summing the prices of a grid produces a
+  // number no report should show — so `value` is omitted for it and sent for everything else.
+  const monetary = event !== "view_item_list";
   const value = items.reduce(
     (sum, item) => sum + item.price * (item.quantity ?? 1),
     0
@@ -154,7 +233,7 @@ export function trackEcommerce(
 
   push("event", event, {
     currency: "ZAR",
-    value: Number(value.toFixed(2)),
+    ...(monetary ? { value: Number(value.toFixed(2)) } : {}),
     items,
     ...extra,
   });

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,161 @@
+// GA4 measurement (#16), behind Consent Mode v2.
+//
+// Every function here is a no-op when `NEXT_PUBLIC_GA_MEASUREMENT_ID` is unset, so a
+// developer without a GA property — and any preview build — runs the real code paths
+// without sending anything. Same degrade-quietly shape as the Shopify layer.
+//
+// WHAT THIS DOES NOT MEASURE: `purchase`. Checkout is handed off to Shopify (#31), so the
+// order is created on Shopify's domain and Shopify's own GA4 integration is what reports
+// the conversion. Firing a `purchase` here would be inventing one, since this site never
+// learns whether payment succeeded. Our funnel ends at `begin_checkout`.
+
+const CONSENT_STORAGE_KEY = "hb-analytics-consent";
+
+/** Inlined at build time, like every NEXT_PUBLIC_ value. Empty means "no analytics". */
+export const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID ?? "";
+
+export function isAnalyticsConfigured(): boolean {
+  return GA_MEASUREMENT_ID !== "";
+}
+
+export type ConsentChoice = "granted" | "denied";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+type GtagArgs = any[];
+
+declare global {
+  interface Window {
+    dataLayer?: GtagArgs[];
+    gtag?: (...args: GtagArgs) => void;
+  }
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+/**
+ * Pushes to `dataLayer` directly rather than calling `window.gtag`.
+ *
+ * The two are equivalent once gtag.js has loaded, but events fired before it finishes
+ * loading would be dropped by a `window.gtag` call that isn't defined yet. `dataLayer` is
+ * created synchronously by the consent bootstrap, so anything queued on it is replayed
+ * when the script arrives — which matters for `view_item`, fired on first paint.
+ */
+function push(...args: GtagArgs): void {
+  if (typeof window === "undefined" || !isAnalyticsConfigured()) return;
+  window.dataLayer = window.dataLayer ?? [];
+  window.dataLayer.push(args);
+}
+
+/** The visitor's stored choice, or null if they haven't answered yet. */
+export function readStoredConsent(): ConsentChoice | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const value = window.localStorage.getItem(CONSENT_STORAGE_KEY);
+    return value === "granted" || value === "denied" ? value : null;
+  } catch {
+    // Private mode, or storage disabled. Treat as "not answered" rather than throwing —
+    // the banner reappearing is a far smaller problem than a crash on first paint.
+    return null;
+  }
+}
+
+export function storeConsent(choice: ConsentChoice): void {
+  try {
+    window.localStorage.setItem(CONSENT_STORAGE_KEY, choice);
+  } catch {
+    // Same reasoning as above: the choice is honoured for this page view either way.
+  }
+  cachedConsent = choice;
+  listeners.forEach((notify) => notify());
+}
+
+/**
+ * `localStorage` as an external store, so the banner can read it with
+ * `useSyncExternalStore` instead of setting state from an effect.
+ *
+ * "unknown" is the SERVER snapshot and exists to keep hydration honest: the server cannot
+ * know the answer, so it renders nothing at all rather than guessing and flashing a banner
+ * at a visitor who already replied. The client resolves it to "pending" or a real choice on
+ * the first commit.
+ */
+export type ConsentState = ConsentChoice | "pending" | "unknown";
+
+let cachedConsent: ConsentState | null = null;
+let listeners: (() => void)[] = [];
+
+export function subscribeConsent(notify: () => void): () => void {
+  listeners = [...listeners, notify];
+  return () => {
+    listeners = listeners.filter((l) => l !== notify);
+  };
+}
+
+export function getConsentSnapshot(): ConsentState {
+  // Cached because useSyncExternalStore requires a stable value between renders — reading
+  // localStorage afresh each call is allowed, but re-deriving "pending" would return a new
+  // value identity only if it were an object, and caching also keeps the read cheap.
+  cachedConsent ??= readStoredConsent() ?? "pending";
+  return cachedConsent;
+}
+
+export function getConsentServerSnapshot(): ConsentState {
+  return "unknown";
+}
+
+/**
+ * Tells Google the visitor has answered. Under Consent Mode v2 a `denied` state still
+ * sends cookieless pings, so traffic shape survives a refusal while nothing identifying
+ * is stored.
+ */
+export function updateConsent(choice: ConsentChoice): void {
+  push("consent", "update", {
+    analytics_storage: choice,
+    ad_storage: "denied",
+    ad_user_data: "denied",
+    ad_personalization: "denied",
+  });
+}
+
+/** A GA4 page_view. Called on route changes, since gtag.js only sees the first load. */
+export function trackPageView(path: string): void {
+  push("event", "page_view", { page_path: path });
+}
+
+export interface AnalyticsItem {
+  item_id: string;
+  item_name: string;
+  price: number;
+  item_category?: string;
+  item_variant?: string;
+  quantity?: number;
+}
+
+type EcommerceEvent =
+  | "view_item"
+  | "view_item_list"
+  | "add_to_cart"
+  | "remove_from_cart"
+  | "view_cart"
+  | "add_to_wishlist"
+  | "begin_checkout";
+
+/**
+ * GA4 ecommerce events all take the same envelope: a currency, a value, and the items.
+ * `currency` is required alongside `value` or GA4 discards the monetary part silently.
+ */
+export function trackEcommerce(
+  event: EcommerceEvent,
+  items: AnalyticsItem[],
+  extra?: Record<string, unknown>
+): void {
+  const value = items.reduce(
+    (sum, item) => sum + item.price * (item.quantity ?? 1),
+    0
+  );
+
+  push("event", event, {
+    currency: "ZAR",
+    value: Number(value.toFixed(2)),
+    items,
+    ...extra,
+  });
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -23,15 +23,23 @@ const AUTH_PAGES = ["/login", "/signup", "/forgot-password"];
  * `style-src` deliberately stays on 'unsafe-inline' with no nonce token: Framer
  * Motion, React style={{}}, next/font and optimizeCss all emit inline styles, and
  * per spec a nonce in a directive makes browsers ignore 'unsafe-inline'.
+ *
+ * GA4 (#16) needs three directives, not one: `script-src` for gtag.js itself,
+ * `connect-src` for the `/g/collect` beacons (which move between the
+ * google-analytics.com and analytics.google.com hosts by region), and `img-src`
+ * for the pixel fallback gtag uses when fetch/sendBeacon is unavailable. Missing
+ * the last two is the classic "the tag loads but no hits arrive" failure. Note the
+ * GA consent bootstrap is deliberately NOT an inline script — see `Analytics.tsx`
+ * for why that would have cost every page its static rendering.
  */
 function buildCsp(nonce: string): string {
   return [
     `default-src 'self'`,
-    `script-src 'self' 'nonce-${nonce}' https://apis.google.com https://accounts.google.com https://www.gstatic.com`,
+    `script-src 'self' 'nonce-${nonce}' https://apis.google.com https://accounts.google.com https://www.gstatic.com https://www.googletagmanager.com`,
     `style-src 'self' 'unsafe-inline'`,
-    `img-src 'self' data: blob: https://cdn.shopify.com https://*.googleusercontent.com`,
+    `img-src 'self' data: blob: https://cdn.shopify.com https://*.googleusercontent.com https://www.google-analytics.com https://www.googletagmanager.com`,
     `font-src 'self' data:`,
-    `connect-src 'self' https://*.googleapis.com https://*.firebaseapp.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com`,
+    `connect-src 'self' https://*.googleapis.com https://*.firebaseapp.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com https://www.google-analytics.com https://analytics.google.com https://*.analytics.google.com https://www.googletagmanager.com`,
     `frame-src 'self' https://*.firebaseapp.com https://accounts.google.com https://appleid.apple.com`,
     `media-src 'self'`,
     `object-src 'none'`,


### PR DESCRIPTION
Closes **#16** — GA4, events and ecommerce tracking — in three reviewable commits.

| Commit | |
| --- | --- |
| `ff2427c` | GA4 loader, Consent Mode v2, consent banner, CSP |
| `9696053` | ecommerce events |
| `1bb6042` | privacy policy page |

## Consent

Storage is **denied by default** and only upgraded when the visitor accepts, so this is correct for
EU/UK visitors as well as POPIA. A denied visitor still sends cookieless pings, so traffic shape
survives a refusal without anything identifying being stored.

**Everything is inert when `NEXT_PUBLIC_GA_MEASUREMENT_ID` is unset** — no script, no banner, every
call a no-op — so local development and deploy previews can't pollute the property.

## Three decisions worth reviewing

**1. The consent default is queued by `push()`, not by a component.** It started in `<Analytics>`'s
effect, and browser testing showed that was wrong: React runs child effects before parent ones, so a
product page's `view_item` fired *before* the consent default — putting a measurement command ahead
of the consent state Google requires to come first. Driving the bootstrap from the first event of any
kind makes the ordering impossible to get wrong.

**2. No inline `<script>`.** Google's snippet is normally inline, and an inline script — unlike the
JSON-LD data blocks from #14 — really *is* subject to `script-src`, so it would need the per-request
nonce, so the layout would need `headers()`, so every page would go dynamic and the product routes
would lose SSG. Same-origin client code needs neither. Build output confirms `/store/<handle>` is
still `●`.

**3. `purchase` is deliberately not tracked.** Checkout is handed off to Shopify, so the order is
created on Shopify's domain and this site never learns whether payment succeeded — firing a
`purchase` here would be inventing one. **Configure the same measurement ID in the Shopify admin**,
or the funnel stops at `begin_checkout` and conversions are never attributed.

## CSP

GA needs **three** directives, not one: `script-src` for gtag.js, `connect-src` for the `/g/collect`
beacons (which move between the google-analytics.com and analytics.google.com hosts by region), and
`img-src` for the pixel fallback. Missing the last two is the classic "tag loads but no hits arrive".

## Events

`view_item_list` · `view_item` · `add_to_cart` · `remove_from_cart` · `add_to_wishlist` ·
`begin_checkout`, plus SPA `page_view`.

Cart events live in `CartContext` because it is the single choke point every mutation already passes
through — the alternative is touching five components and missing one later. They fire **outside**
the state updater, since StrictMode invokes updaters twice and would double-count.

`removeItem`/`updateQuantity` now depend on `items`, which costs nothing: the provider's value is an
inline object literal, so it is rebuilt every render and no consumer relied on a stable identity.

## Privacy policy

The footer already advertised a "Privacy Policy" link pointing at `#`, and running GA4 with no policy
is a gap under POPIA and GDPR. `/privacy` describes what the code actually does — every processor and
storage key named is checkable against the source.

**It carries a visible "Draft — pending review" notice.** An accurate description of the data flows
is not reviewed legal copy; that notice should come off only once someone qualified has read it.
Terms and Accessibility remain `#` placeholders and want their own issue.

## Verification

`lint` · `typecheck` · `build` pass. Beyond that, driven in a real browser against a **production**
build — several of these could not have been caught any other way:

| Check | Result |
| --- | --- |
| dataLayer order | `consent default` → `js` → `config` → events ✅ |
| Event duplication | each fires **once** in production (twice in dev = StrictMode) ✅ |
| `add_to_cart` | real variant SKU `45578276012211`, `R100`, ZAR, qty 1 ✅ |
| `remove_from_cart` | correct item and quantity ✅ |
| `view_item_list` | 3 items, `item_list_name: Store`, **no** `value` ✅ |
| Accept | `consent update granted`, persisted, banner removed ✅ |
| No measurement ID | no gtag script at all ✅ |
| SSR | banner absent from server HTML, so no flash for returning visitors ✅ |

**Two bugs found and fixed during that testing**, both invisible to lint and typecheck:

1. The consent-ordering problem above.
2. `ConsentBanner` used `AnimatePresence`, whose exit animation ran to completion but **never
   unmounted the node** — leaving an invisible `position: fixed` strip across the bottom of every
   page that intercepted clicks, confirmed with `elementFromPoint`. Reproduced with and without a
   `key`. It now animates in and simply stops rendering; the fade-out was worth far less than a
   working footer.

## Note for whoever merges after #99

`toAnalyticsItem` drops the `"Product"` category fallback with its own inline check, matching what
the JSON-LD builder does. #99 extracts both onto a shared `meaningfulCategory()` helper — this should
collapse onto it once that lands. Flagged in a comment at the site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0135pq3mk9wVb8YWb6EVzufp